### PR TITLE
Version 8: xd spec compliant markup, and adds direction on the clue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 This isn't a comprehensive doc because to our knowledge there are no OSS consumers of this lib, but for posterities sake here are the breaking changes:
 
+### 8.0.1
+
+After 3 separate attempts to figure out markup support in clues, we've settled on the xd spec compliant version of "markdown with a curly brace."
+
+In the process we've dropped `bodyMD` as an optional field on a clue, and switched over to having a "display" field on the clue which should really always be used when presenting a clue for user-facing cases. It is a tuple array indicating how to present chunks of the clue incrementally.
+
+<!-- prettier-ignore -->
+```md
+A1. {/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@} ~ AHAB
+```
+
+Turns into:
+
+```json
+{
+  "answer": "AHAB",
+  "body": "{/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@}",
+  "display": [
+    ["italics", "Captain"],
+    ["text", ", "],
+    ["bold", "of"],
+    ["text", ", "],
+    ["underscore", "the"],
+    ["text", ", ship "],
+    ["strike", "pequod"],
+    ["text", " "],
+    ["link", "see here", "https://mylink.com"]
+  ]
+}
+```
+
+Also adds "direction" on the clue, it's a tiny micro-optimization, but when you are writing tools which interact with clues, you're often keeping track of this separately - might as well move it inline properly.
+
+### 7.x.x
+
+A brief sojourn into using BBCode as the markup language for clues.
+
 ### 6.6.0
 
 A chunky re-write of the markdown parser now that it's actually in use at Puzzmo, see the README for an up-to-date look at what we think it should do.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const cursorInfo = info(0, 0)
 
 Which returns a union of different results, you can check the types + tests to see what's available, but it's something like this:
 
-```ts
+```tss
 export type PositionInfo =
   | { type: "noop" }
   | { type: "grid"; position: Position }
@@ -4310,71 +4310,71 @@ This lib creates `xd` compatible files, but also extends the format in a way tha
 
 #### Structural
 
-- Headers - `xd` out of the box has an implicit order:
+Headers - `xd` out of the box has an implicit order:
 
-  - Meta
-  - Grid
-  - Clues
-  - Notes (optional)
+- Meta
+- Grid
+- Clues
+- Notes (optional)
 
-  This library respects that behavior, but also supports a markdown header format whereby you could write an `xd` document like:
+This library respects that behavior, but also supports a markdown header format whereby you could write an `xd` document like:
 
-  ```md
-  ## Metadata
+```md
+## Metadata
 
-  Title: Square
-  Author: Orta
-  Editor: Orta Therox
-  Date: 2021-03-16
+Title: Square
+Author: Orta
+Editor: Orta Therox
+Date: 2021-03-16
 
-  ## Grid
+## Grid
 
-  BULB
-  OK#O
-  L##O
-  DESK
+BULB
+OK#O
+L##O
+DESK
 
-  ## Clues
+## Clues
 
-  A1. Gardener's concern. ~ BULB
-  A4. A reasonable statement. ~ OK
-  A5. The office centerpiece. ~ DESK
+A1. Gardener's concern. ~ BULB
+A4. A reasonable statement. ~ OK
+A5. The office centerpiece. ~ DESK
 
-  D1. To \_ly go. ~ BOLD
-  D2. Bigger than britain. ~ UK
-  D3. A conscious tree. ~ BOOK
-  ```
+D1. To \_ly go. ~ BOLD
+D2. Bigger than britain. ~ UK
+D3. A conscious tree. ~ BOOK
+```
 
-  This makes the sections a bit more explicit (and conceptually more user-friendly if you have not read the xd documentation ahead of seeing the file) and frees the order in which someone could write a document. Capitalization is ignored.
+This makes the sections a bit more explicit (and conceptually more user-friendly if you have not read the xd documentation ahead of seeing the file) and frees the order in which someone could write a document. Capitalization is ignored.
 
-- ##### Clue Metadata
+##### Clue Metadata
 
-  You can add arbitrary metadata to clues by repeating the clue with a custom suffix:
+You can add arbitrary metadata to clues by repeating the clue with a custom suffix:
 
-  ```md
-  A1. Gardener's concerns with A2 and D4. ~ BULB
-  A1 ^Hint: Turned on to illuminate a room.
-  A1 ^Refs: A2 D4
+```md
+A1. Gardener's concerns with A2 and D4. ~ BULB
+A1 ^Hint: Turned on to illuminate a room.
+A1 ^Refs: A2 D4
 
-  A4. A reasonable statement. ~ OK
-  A4 ^Hint: All \_\_.
+A4. A reasonable statement. ~ OK
+A4 ^Hint: All \_\_.
 
-  A5. The office centerpiece. ~ DESK
-  A5 ^Hint: Fried.
+A5. The office centerpiece. ~ DESK
+A5 ^Hint: Fried.
 
-  D1. To \_ly go. ~ BOLD
-  D1 ^Hint: When you want to make some text stronger.
+D1. To \_ly go. ~ BOLD
+D1 ^Hint: When you want to make some text stronger.
 
-  D2. Bigger than britain. ~ UK
-  D2 ^Hint: A union which left europe.
+D2. Bigger than britain. ~ UK
+D2 ^Hint: A union which left europe.
 
-  D3. A conscious tree. ~ BOOK
-  D3 ^Hint: Registering with a restaurant. ~ BOOK
-  ```
+D3. A conscious tree. ~ BOOK
+D3 ^Hint: Registering with a restaurant. ~ BOOK
+```
 
-  Capitalization is ignored, the metadata prefix will always be given as lowercase inside the JSON representation.
+Capitalization is ignored, the metadata prefix will always be given as lowercase inside the JSON representation.
 
-- ##### Markdown/HTML style comments
+##### Markdown/HTML style comments
 
 In markdown you can write `<!--` and `-->` to comment out a section of your code. Our implementation is not _super_ smart:
 
@@ -4395,7 +4395,7 @@ Date: 2021-03-16
 
 The key is that a line has to start with `<!--` and eventually the same or another line has to **end** with `-->`.
 
-- ##### Markup in Clues
+##### Markup in Clues
 
 The [xd spec](https://github.com/century-arcade/xd/blob/master/doc/xd-format.md#clues-section-3) defines markup inside a clue as roughly being "markdown sigil's wrapped in `{` and `}`". We support this format, and will always fill out a key of `markup` which is an array of components. We also add support for links via this syntax: `{@text|url@}`.
 
@@ -4430,72 +4430,76 @@ Which will add the optional `"bodyMD"` to the clue:
 - Underline: `{_`<key>words</key>`_}`
 - Link: `{@`<key>words</key>`|<key>url</key>@}`
 
-- ##### Split character
+##### Split character
 
-  Provide hints for where one word terminates and the next begins in a single solution by declaring `SplitCharacter: {character}` in `Metadata`, and adding the chosen SplitCharacter between words in `Clues`.
+Provide hints for where one word terminates and the next begins in a single solution by declaring `SplitCharacter: {character}` in `Metadata`, and adding the chosen SplitCharacter between words in `Clues`.
 
-  ```
-  ## Metadata
-  SplitCharacter: |
+```
+## Metadata
+SplitCharacter: |
 
-  ## Clues
-  …
-  D25. Father of Spider-Man ~ STAN|LEE
-  ```
+## Clues
+…
+D25. Father of Spider-Man ~ STAN|LEE
+```
 
-  The 'answer' given from the parser here will be 'STANLEE', but the indexes for each bar will be noted in the clue.
+The 'answer' given from the parser here will be 'STANLEE', but the indexes for each bar will be noted in the clue.
 
 ### Spec-Breaking Differences
 
-We want to highlight that 'Clue Metadata', 'Comments' and 'Split Characters' are all spec-breaking extensions. E.g. a parser which conforms exactly to the xd spec would likely choke when seeing these features.
+We want to highlight that 'Comments', 'Split Characters' and some markup extensions are all spec-breaking. E.g. a parser which conforms exactly to the xd spec would likely choke when seeing these features.
 
-We'd be open to a variant of our `JSONToXD` function which produces spec-compliant versions of the xd files instead of just our extensions.
+Otherwise, we keep all extensions inside a unique section which another xp parser would know to NOOP on.
 
 #### Metadata
 
-- [Shrodinger's Squares](https://www.xwordinfo.com/Quantum). It's likely that a special form of Rebus will work here, for example:
+**Not yet supported**: This is our guess
 
-  ```
-  Rebus: 1=M|F
-  ```
+[Shrodinger's Squares](https://www.xwordinfo.com/Quantum). It's likely that a special form of Rebus will work here, for example:
 
-  Indicates to the game engine that the rebus for `1` on the grid can be _either_ `M` or `F`.
+```
+Rebus: 1=M|F
+```
 
-  ```
-  Rebus: 1=M&F 2=L&T
-  ```
+Indicates to the game engine that the rebus for `1` on the grid can be _either_ `M` or `F`.
 
-  Indicates to the game engine that the rebus for `1` on the grid can be _either_ `M` or `F`, but that the side needs to be respected across all possible rebuses in the clue. So for `M1L2` you could have `MALE` and `FATE`but not `FALE` or `MATE`.
+```
+Rebus: 1=M&F 2=L&T
+```
 
-#### Notes
+Indicates to the game engine that the rebus for `1` on the grid can be _either_ `M` or `F`, but that the side needs to be respected across all possible rebuses in the clue. So for `M1L2` you could have `MALE` and `FATE`but not `FALE` or `MATE`.
+
+#### Aesthetics
+
+The xd spec is built for isplaying a large corpus of finished Crosswords, we use it for creation of new ones. This means we have a few extensions to the format to make it easier to write puzzles.
 
 - `## Design`
 
-  This is our extension to describe the visual aspects of individual cells. The `xd` format uses lowercase letters in the grid to indicate a particular special trait (for example having a circle background.) We are looking at describing a more complex set of visual attributes, and so the puz -> xd parser uses a new section to indicate the design attributes in a manner similar to how rebuses are handled.
+This is our extension to describe the visual aspects of individual cells. The `xd` format uses lowercase letters in the grid to indicate a particular special trait (for example having a circle background.) We are looking at describing a more complex set of visual attributes, and so the puz -> xd parser uses a new section to indicate the design attributes in a manner similar to how rebuses are handled.
 
-  ```md
-  ## Design
+```md
+## Design
 
-  <style>
-  O { background: circle }
-  </style>
+<style>
+O { background: circle }
+</style>
 
-  ....###...#....
-  ....##....#....
-  ....#.....#....
-  ............###
-  ...#....##....#
-  ......#....O...
-  ##...#....#O...
-  ..O....#...O...
-  ..O.#....#.O.##
-  ..O.....#..O...
-  #.OO.##....#O..
-  ###O........O..
-  ...O#.....#.O..
-  ...O#....##.O..
-  ...O#...###.O..
-  ```
+....###...#....
+....##....#....
+....#.....#....
+............###
+...#....##....#
+......#....O...
+##...#....#O...
+..O....#...O...
+..O.#....#.O.##
+..O.....#..O...
+#.OO.##....#O..
+###O........O..
+...O#.....#.O..
+...O#....##.O..
+...O#...###.O..
+```
 
 - `## Start`
 
@@ -4521,8 +4525,21 @@ We'd be open to a variant of our `JSONToXD` function which produces spec-complia
   .....#...##....
   ```
 
+- `## Metapuzzle`
+
+  We'd like a way to describe a final question and a final answer for a puzzle. For example, in alpha-bits above the circles indicate a letter pattern and there could be a way to respond that you got the theme. For example:
+
+  ```md
+  ## Metapuzzle
+
+  How are the words sorted?
+
+  > Alphabetic
+  ```
+
+  Case in the answer should be ignored by engines.
+
 ### Filetypes this lib is open to adding
 
 - http://www.ipuz.org
 - https://www.xwordinfo.com/XPF/ / https://www.xwordinfo.com/JSON/
-- jpz

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const cursorInfo = info(0, 0)
 
 Which returns a union of different results, you can check the types + tests to see what's available, but it's something like this:
 
-```tss
+```ts
 export type PositionInfo =
   | { type: "noop" }
   | { type: "grid"; position: Position }
@@ -1171,10 +1171,30 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "B"
+          }
+        ],
         "metadata": {
           "body:line": "28",
           "answer:unprocessed": "AHAB"
-        }
+        },
+        "display": [["text", "Captain of the Pequod"]],
+        "direction": "across"
       },
       {
         "body": "Food for second chance chewing",
@@ -1184,10 +1204,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "U"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          }
+        ],
         "metadata": {
           "body:line": "29",
           "answer:unprocessed": "CUD"
-        }
+        },
+        "display": [["text", "Food for second chance chewing"]],
+        "direction": "across"
       },
       {
         "body": "Font feature",
@@ -1197,10 +1233,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "F"
+          }
+        ],
         "metadata": {
           "body:line": "30",
           "answer:unprocessed": "SERIF"
-        }
+        },
+        "display": [["text", "Font feature"]],
+        "direction": "across"
       },
       {
         "body": "Palindromic address to a female",
@@ -1210,10 +1270,34 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 1
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "M"
+          }
+        ],
         "metadata": {
           "body:line": "31",
           "answer:unprocessed": "MADAM"
-        }
+        },
+        "display": [["text", "Palindromic address to a female"]],
+        "direction": "across"
       },
       {
         "body": "___ Way You Want It",
@@ -1223,10 +1307,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 1
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          }
+        ],
         "metadata": {
           "body:line": "32",
           "answer:unprocessed": "ANY"
-        }
+        },
+        "display": [["text", "___ Way You Want It"]],
+        "direction": "across"
       },
       {
         "body": "Place often described as humble",
@@ -1236,10 +1336,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 1
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "B"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "33",
           "answer:unprocessed": "ABODE"
-        }
+        },
+        "display": [["text", "Place often described as humble"]],
+        "direction": "across"
       },
       {
         "body": "Flat two dimensional surface in geometry",
@@ -1249,10 +1373,34 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 2
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "34",
           "answer:unprocessed": "PLANE"
-        }
+        },
+        "display": [["text", "Flat two dimensional surface in geometry"]],
+        "direction": "across"
       },
       {
         "body": "Grim homophone of 7D",
@@ -1262,10 +1410,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 2
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "35",
           "answer:unprocessed": "DIE"
-        }
+        },
+        "display": [["text", "Grim homophone of 7D"]],
+        "direction": "across"
       },
       {
         "body": "Off",
@@ -1275,10 +1439,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 2
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "36",
           "answer:unprocessed": "NOTON"
-        }
+        },
+        "display": [["text", "Off"]],
+        "direction": "across"
       },
       {
         "body": "Heading for some lists",
@@ -1288,10 +1476,30 @@ O..O.#O.O##O..O
           "col": 4,
           "index": 3
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          }
+        ],
         "metadata": {
           "body:line": "37",
           "answer:unprocessed": "TODO"
-        }
+        },
+        "display": [["text", "Heading for some lists"]],
+        "direction": "across"
       },
       {
         "body": "Kanye West is famous for his",
@@ -1301,10 +1509,26 @@ O..O.#O.O##O..O
           "col": 9,
           "index": 3
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "G"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          }
+        ],
         "metadata": {
           "body:line": "38",
           "answer:unprocessed": "EGO"
-        }
+        },
+        "display": [["text", "Kanye West is famous for his"]],
+        "direction": "across"
       },
       {
         "body": "Laceration",
@@ -1314,10 +1538,30 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "G"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          }
+        ],
         "metadata": {
           "body:line": "39",
           "answer:unprocessed": "GASH"
-        }
+        },
+        "display": [["text", "Laceration"]],
+        "direction": "across"
       },
       {
         "body": "Alias of Twitch star Richard Tyler Blevins",
@@ -1327,10 +1571,34 @@ O..O.#O.O##O..O
           "col": 5,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "J"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "40",
           "answer:unprocessed": "NINJA"
-        }
+        },
+        "display": [["text", "Alias of Twitch star Richard Tyler Blevins"]],
+        "direction": "across"
       },
       {
         "body": "Capsize",
@@ -1340,10 +1608,30 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "K"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          }
+        ],
         "metadata": {
           "body:line": "41",
           "answer:unprocessed": "KEEL"
-        }
+        },
+        "display": [["text", "Capsize"]],
+        "direction": "across"
       },
       {
         "body": "Piece of clothing or print",
@@ -1353,10 +1641,42 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 5
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "42",
           "answer:unprocessed": "ARTICLE"
-        }
+        },
+        "display": [["text", "Piece of clothing or print"]],
+        "direction": "across"
       },
       {
         "body": "Evangelical school in Tulsa, OK",
@@ -1366,10 +1686,26 @@ O..O.#O.O##O..O
           "col": 8,
           "index": 5
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "U"
+          }
+        ],
         "metadata": {
           "body:line": "43",
           "answer:unprocessed": "ORU"
-        }
+        },
+        "display": [["text", "Evangelical school in Tulsa, OK"]],
+        "direction": "across"
       },
       {
         "body": "___-eyed",
@@ -1379,10 +1715,26 @@ O..O.#O.O##O..O
           "col": 12,
           "index": 5
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "44",
           "answer:unprocessed": "DOE"
-        }
+        },
+        "display": [["text", "___-eyed"]],
+        "direction": "across"
       },
       {
         "body": "Annual",
@@ -1392,10 +1744,38 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 6
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "Y"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          }
+        ],
         "metadata": {
           "body:line": "45",
           "answer:unprocessed": "YEARLY"
-        }
+        },
+        "display": [["text", "Annual"]],
+        "direction": "across"
       },
       {
         "body": "The stamp with the upside down airplane is a famous one",
@@ -1405,10 +1785,46 @@ O..O.#O.O##O..O
           "col": 7,
           "index": 6
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "46",
           "answer:unprocessed": "MISPRINT"
-        }
+        },
+        "display": [["text", "The stamp with the upside down airplane is a famous one"]],
+        "direction": "across"
       },
       {
         "body": "With 42A and Marcus, a luxury department store chain",
@@ -1418,10 +1834,26 @@ O..O.#O.O##O..O
           "col": 2,
           "index": 7
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          }
+        ],
         "metadata": {
           "body:line": "47",
           "answer:unprocessed": "NEI"
-        }
+        },
+        "display": [["text", "With 42A and Marcus, a luxury department store chain"]],
+        "direction": "across"
       },
       {
         "body": "41A continued",
@@ -1431,10 +1863,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 7
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "48",
           "answer:unprocessed": "MAN"
-        }
+        },
+        "display": [["text", "41A continued"]],
+        "direction": "across"
       },
       {
         "body": "Lush",
@@ -1444,10 +1892,26 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 7
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "49",
           "answer:unprocessed": "SOT"
-        }
+        },
+        "display": [["text", "Lush"]],
+        "direction": "across"
       },
       {
         "body": "The Mayan one ended in 2012",
@@ -1457,10 +1921,46 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          }
+        ],
         "metadata": {
           "body:line": "50",
           "answer:unprocessed": "CALENDAR"
-        }
+        },
+        "display": [["text", "The Mayan one ended in 2012"]],
+        "direction": "across"
       },
       {
         "body": "What a child often does to their shoes",
@@ -1470,10 +1970,38 @@ O..O.#O.O##O..O
           "col": 9,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "51",
           "answer:unprocessed": "RETIES"
-        }
+        },
+        "display": [["text", "What a child often does to their shoes"]],
+        "direction": "across"
       },
       {
         "body": "Vanilla ___",
@@ -1483,10 +2011,26 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 9
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "52",
           "answer:unprocessed": "ICE"
-        }
+        },
+        "display": [["text", "Vanilla ___"]],
+        "direction": "across"
       },
       {
         "body": "Maligned cigarette ingredient",
@@ -1496,10 +2040,26 @@ O..O.#O.O##O..O
           "col": 4,
           "index": 9
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          }
+        ],
         "metadata": {
           "body:line": "53",
           "answer:unprocessed": "TAR"
-        }
+        },
+        "display": [["text", "Maligned cigarette ingredient"]],
+        "direction": "across"
       },
       {
         "body": "Frequent cause for a new tire",
@@ -1509,10 +2069,42 @@ O..O.#O.O##O..O
           "col": 8,
           "index": 9
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "54",
           "answer:unprocessed": "POTHOLE"
-        }
+        },
+        "display": [["text", "Frequent cause for a new tire"]],
+        "direction": "across"
       },
       {
         "body": "Los Angeles heavy metal act",
@@ -1522,10 +2114,30 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 10
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "P"
+          }
+        ],
         "metadata": {
           "body:line": "55",
           "answer:unprocessed": "OTEP"
-        }
+        },
+        "display": [["text", "Los Angeles heavy metal act"]],
+        "direction": "across"
       },
       {
         "body": "Bldgs. such as the Googleplex",
@@ -1535,10 +2147,34 @@ O..O.#O.O##O..O
           "col": 5,
           "index": 10
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "Q"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "56",
           "answer:unprocessed": "HQTRS"
-        }
+        },
+        "display": [["text", "Bldgs. such as the Googleplex"]],
+        "direction": "across"
       },
       {
         "body": "A fit of irritation",
@@ -1548,10 +2184,30 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 10
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "57",
           "answer:unprocessed": "SNIT"
-        }
+        },
+        "display": [["text", "A fit of irritation"]],
+        "direction": "across"
       },
       {
         "body": "Lead-in to American or day",
@@ -1561,10 +2217,26 @@ O..O.#O.O##O..O
           "col": 3,
           "index": 11
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          }
+        ],
         "metadata": {
           "body:line": "58",
           "answer:unprocessed": "ALL"
-        }
+        },
+        "display": [["text", "Lead-in to American or day"]],
+        "direction": "across"
       },
       {
         "body": "What Pokémon do at a Pokémon Center",
@@ -1574,10 +2246,30 @@ O..O.#O.O##O..O
           "col": 7,
           "index": 11
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          }
+        ],
         "metadata": {
           "body:line": "59",
           "answer:unprocessed": "HEAL"
-        }
+        },
+        "display": [["text", "What Pokémon do at a Pokémon Center"]],
+        "direction": "across"
       },
       {
         "body": "Nixon's vice",
@@ -1587,10 +2279,34 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          }
+        ],
         "metadata": {
           "body:line": "60",
           "answer:unprocessed": "SPIRO"
-        }
+        },
+        "display": [["text", "Nixon's vice"]],
+        "direction": "across"
       },
       {
         "body": "Nothing but ___",
@@ -1600,10 +2316,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "61",
           "answer:unprocessed": "NET"
-        }
+        },
+        "display": [["text", "Nothing but ___"]],
+        "direction": "across"
       },
       {
         "body": "One with the world on his shoulders",
@@ -1613,10 +2345,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "62",
           "answer:unprocessed": "ATLAS"
-        }
+        },
+        "display": [["text", "One with the world on his shoulders"]],
+        "direction": "across"
       },
       {
         "body": "Filled pastries",
@@ -1626,10 +2382,34 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 13
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "63",
           "answer:unprocessed": "TARTS"
-        }
+        },
+        "display": [["text", "Filled pastries"]],
+        "direction": "across"
       },
       {
         "body": "Age, in Milan",
@@ -1639,10 +2419,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 13
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "64",
           "answer:unprocessed": "ETA"
-        }
+        },
+        "display": [["text", "Age, in Milan"]],
+        "direction": "across"
       },
       {
         "body": "Lorna ___, novel or cookie",
@@ -1652,10 +2448,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 13
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "65",
           "answer:unprocessed": "DOONE"
-        }
+        },
+        "display": [["text", "Lorna ___, novel or cookie"]],
+        "direction": "across"
       },
       {
         "body": "Electrocardiogram readout feature",
@@ -1665,10 +2485,34 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 14
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "U"
+          },
+          {
+            "type": "letter",
+            "letter": "W"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "V"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "66",
           "answer:unprocessed": "UWAVE"
-        }
+        },
+        "display": [["text", "Electrocardiogram readout feature"]],
+        "direction": "across"
       },
       {
         "body": "Hip slang for records",
@@ -1678,10 +2522,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 14
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "W"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "X"
+          }
+        ],
         "metadata": {
           "body:line": "67",
           "answer:unprocessed": "WAX"
-        }
+        },
+        "display": [["text", "Hip slang for records"]],
+        "direction": "across"
       },
       {
         "body": "Yiddish for a foolish person",
@@ -1691,10 +2551,30 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 14
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "Y"
+          },
+          {
+            "type": "letter",
+            "letter": "U"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "Z"
+          }
+        ],
         "metadata": {
           "body:line": "68",
           "answer:unprocessed": "YUTZ"
-        }
+        },
+        "display": [["text", "Yiddish for a foolish person"]],
+        "direction": "across"
       }
     ],
     "down": [
@@ -1706,10 +2586,26 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "P"
+          }
+        ],
         "metadata": {
           "body:line": "70",
           "answer:unprocessed": "AMP"
-        }
+        },
+        "display": [["text", "Pc. of concert gear"]],
+        "direction": "down"
       },
       {
         "body": "AI antagonist of 2001",
@@ -1719,10 +2615,26 @@ O..O.#O.O##O..O
           "col": 1,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          }
+        ],
         "metadata": {
           "body:line": "71",
           "answer:unprocessed": "HAL"
-        }
+        },
+        "display": [["text", "AI antagonist of 2001"]],
+        "direction": "down"
       },
       {
         "body": "Programming pioneer Lovelace",
@@ -1732,10 +2644,26 @@ O..O.#O.O##O..O
           "col": 2,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "72",
           "answer:unprocessed": "ADA"
-        }
+        },
+        "display": [["text", "Programming pioneer Lovelace"]],
+        "direction": "down"
       },
       {
         "body": "Prohibit",
@@ -1745,10 +2673,26 @@ O..O.#O.O##O..O
           "col": 3,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "B"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "73",
           "answer:unprocessed": "BAN"
-        }
+        },
+        "display": [["text", "Prohibit"]],
+        "direction": "down"
       },
       {
         "body": "Type of person to routinely carry a club",
@@ -1758,10 +2702,38 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "74",
           "answer:unprocessed": "CADDIE"
-        }
+        },
+        "display": [["text", "Type of person to routinely carry a club"]],
+        "direction": "down"
       },
       {
         "body": "State of the ___ Address",
@@ -1771,10 +2743,34 @@ O..O.#O.O##O..O
           "col": 7,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "U"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "75",
           "answer:unprocessed": "UNION"
-        }
+        },
+        "display": [["text", "State of the ___ Address"]],
+        "direction": "down"
       },
       {
         "body": "Colorful homophone of 18A",
@@ -1784,10 +2780,26 @@ O..O.#O.O##O..O
           "col": 8,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "76",
           "answer:unprocessed": "DYE"
-        }
+        },
+        "display": [["text", "Colorful homophone of 18A"]],
+        "direction": "down"
       },
       {
         "body": "Snitched",
@@ -1797,10 +2809,30 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "G"
+          }
+        ],
         "metadata": {
           "body:line": "77",
           "answer:unprocessed": "SANG"
-        }
+        },
+        "display": [["text", "Snitched"]],
+        "direction": "down"
       },
       {
         "body": "Kindle fare",
@@ -1810,10 +2842,34 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "B"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "K"
+          }
+        ],
         "metadata": {
           "body:line": "78",
           "answer:unprocessed": "EBOOK"
-        }
+        },
+        "display": [["text", "Kindle fare"]],
+        "direction": "down"
       },
       {
         "body": "Decayed matter",
@@ -1823,10 +2879,26 @@ O..O.#O.O##O..O
           "col": 12,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "79",
           "answer:unprocessed": "ROT"
-        }
+        },
+        "display": [["text", "Decayed matter"]],
+        "direction": "down"
       },
       {
         "body": "Type of response you hope to get at the altar",
@@ -1836,10 +2908,26 @@ O..O.#O.O##O..O
           "col": 13,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          }
+        ],
         "metadata": {
           "body:line": "80",
           "answer:unprocessed": "IDO"
-        }
+        },
+        "display": [["text", "Type of response you hope to get at the altar"]],
+        "direction": "down"
       },
       {
         "body": "Peat-accumulating wetland",
@@ -1849,10 +2937,26 @@ O..O.#O.O##O..O
           "col": 14,
           "index": 0
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "F"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "81",
           "answer:unprocessed": "FEN"
-        }
+        },
+        "display": [["text", "Peat-accumulating wetland"]],
+        "direction": "down"
       },
       {
         "body": "The ___, NY art museum",
@@ -1862,10 +2966,26 @@ O..O.#O.O##O..O
           "col": 4,
           "index": 1
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "82",
           "answer:unprocessed": "MET"
-        }
+        },
+        "display": [["text", "The ___, NY art museum"]],
+        "direction": "down"
       },
       {
         "body": "___Fans",
@@ -1875,10 +2995,30 @@ O..O.#O.O##O..O
           "col": 5,
           "index": 3
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          }
+        ],
         "metadata": {
           "body:line": "83",
           "answer:unprocessed": "ONLY"
-        }
+        },
+        "display": [["text", "___Fans"]],
+        "direction": "down"
       },
       {
         "body": "Friends, Romans, countrymen, lend me your...",
@@ -1888,10 +3028,30 @@ O..O.#O.O##O..O
           "col": 9,
           "index": 3
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "84",
           "answer:unprocessed": "EARS"
-        }
+        },
+        "display": [["text", "Friends, Romans, countrymen, lend me your..."]],
+        "direction": "down"
       },
       {
         "body": "\"Friend of Dorothy\"",
@@ -1901,10 +3061,26 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "G"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          }
+        ],
         "metadata": {
           "body:line": "85",
           "answer:unprocessed": "GAY"
-        }
+        },
+        "display": [["text", "\"Friend of Dorothy\""]],
+        "direction": "down"
       },
       {
         "body": "We ___ the Champions",
@@ -1914,10 +3090,26 @@ O..O.#O.O##O..O
           "col": 1,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "86",
           "answer:unprocessed": "ARE"
-        }
+        },
+        "display": [["text", "We ___ the Champions"]],
+        "direction": "down"
       },
       {
         "body": "Father of Spider-Man",
@@ -1927,10 +3119,42 @@ O..O.#O.O##O..O
           "col": 2,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "87",
           "answer:unprocessed": "STANLEE"
-        }
+        },
+        "display": [["text", "Father of Spider-Man"]],
+        "direction": "down"
       },
       {
         "body": "What a certain applicant becomes",
@@ -1940,10 +3164,34 @@ O..O.#O.O##O..O
           "col": 3,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "88",
           "answer:unprocessed": "HIREE"
-        }
+        },
+        "display": [["text", "What a certain applicant becomes"]],
+        "direction": "down"
       },
       {
         "body": "Connect",
@@ -1953,10 +3201,30 @@ O..O.#O.O##O..O
           "col": 8,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "J"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "89",
           "answer:unprocessed": "JOIN"
-        }
+        },
+        "display": [["text", "Connect"]],
+        "direction": "down"
       },
       {
         "body": "Particular form of a published text",
@@ -1966,10 +3234,42 @@ O..O.#O.O##O..O
           "col": 12,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "90",
           "answer:unprocessed": "EDITION"
-        }
+        },
+        "display": [["text", "Particular form of a published text"]],
+        "direction": "down"
       },
       {
         "body": "Suffix at the end of all of Eevee's evolutions",
@@ -1979,10 +3279,26 @@ O..O.#O.O##O..O
           "col": 13,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          }
+        ],
         "metadata": {
           "body:line": "91",
           "answer:unprocessed": "EON"
-        }
+        },
+        "display": [["text", "Suffix at the end of all of Eevee's evolutions"]],
+        "direction": "down"
       },
       {
         "body": "Live and ___ Die",
@@ -1992,10 +3308,26 @@ O..O.#O.O##O..O
           "col": 14,
           "index": 4
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "92",
           "answer:unprocessed": "LET"
-        }
+        },
+        "display": [["text", "Live and ___ Die"]],
+        "direction": "down"
       },
       {
         "body": "Famous Eastwood whose name became a famous Gorillaz song",
@@ -2005,10 +3337,34 @@ O..O.#O.O##O..O
           "col": 4,
           "index": 5
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "93",
           "answer:unprocessed": "CLINT"
-        }
+        },
+        "display": [["text", "Famous Eastwood whose name became a famous Gorillaz song"]],
+        "direction": "down"
       },
       {
         "body": "Unexpected result in a sporting competition",
@@ -2018,10 +3374,34 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 5
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "U"
+          },
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "94",
           "answer:unprocessed": "UPSET"
-        }
+        },
+        "display": [["text", "Unexpected result in a sporting competition"]],
+        "direction": "down"
       },
       {
         "body": "Disfigure",
@@ -2031,10 +3411,26 @@ O..O.#O.O##O..O
           "col": 7,
           "index": 6
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          }
+        ],
         "metadata": {
           "body:line": "95",
           "answer:unprocessed": "MAR"
-        }
+        },
+        "display": [["text", "Disfigure"]],
+        "direction": "down"
       },
       {
         "body": "David Lee and Tim",
@@ -2044,10 +3440,34 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 6
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          }
+        ],
         "metadata": {
           "body:line": "96",
           "answer:unprocessed": "ROTHS"
-        }
+        },
+        "display": [["text", "David Lee and Tim"]],
+        "direction": "down"
       },
       {
         "body": "Luxury watch collection by Garmin",
@@ -2057,10 +3477,30 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 7
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "M"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "Q"
+          }
+        ],
         "metadata": {
           "body:line": "97",
           "answer:unprocessed": "MARQ"
-        }
+        },
+        "display": [["text", "Luxury watch collection by Garmin"]],
+        "direction": "down"
       },
       {
         "body": "Top dog in an IT org",
@@ -2070,10 +3510,26 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          }
+        ],
         "metadata": {
           "body:line": "98",
           "answer:unprocessed": "CIO"
-        }
+        },
+        "display": [["text", "Top dog in an IT org"]],
+        "direction": "down"
       },
       {
         "body": "Sister ___",
@@ -2083,10 +3539,26 @@ O..O.#O.O##O..O
           "col": 1,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "C"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "99",
           "answer:unprocessed": "ACT"
-        }
+        },
+        "display": [["text", "Sister ___"]],
+        "direction": "down"
       },
       {
         "body": "Author Roald",
@@ -2096,10 +3568,30 @@ O..O.#O.O##O..O
           "col": 5,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "D"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          }
+        ],
         "metadata": {
           "body:line": "100",
           "answer:unprocessed": "DAHL"
-        }
+        },
+        "display": [["text", "Author Roald"]],
+        "direction": "down"
       },
       {
         "body": "Civil rights activist Parks",
@@ -2109,10 +3601,30 @@ O..O.#O.O##O..O
           "col": 9,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "101",
           "answer:unprocessed": "ROSA"
-        }
+        },
+        "display": [["text", "Civil rights activist Parks"]],
+        "direction": "down"
       },
       {
         "body": "An additional name that could be part of 40D's clue",
@@ -2122,10 +3634,26 @@ O..O.#O.O##O..O
           "col": 13,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "I"
+          }
+        ],
         "metadata": {
           "body:line": "102",
           "answer:unprocessed": "ELI"
-        }
+        },
+        "display": [["text", "An additional name that could be part of 40D's clue"]],
+        "direction": "down"
       },
       {
         "body": "Director's domain",
@@ -2135,10 +3663,26 @@ O..O.#O.O##O..O
           "col": 14,
           "index": 8
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "103",
           "answer:unprocessed": "SET"
-        }
+        },
+        "display": [["text", "Director's domain"]],
+        "direction": "down"
       },
       {
         "body": "Type of income to go in a 401k",
@@ -2148,10 +3692,38 @@ O..O.#O.O##O..O
           "col": 8,
           "index": 9
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "X"
+          }
+        ],
         "metadata": {
           "body:line": "104",
           "answer:unprocessed": "PRETAX"
-        }
+        },
+        "display": [["text", "Type of income to go in a 401k"]],
+        "direction": "down"
       },
       {
         "body": "The Empire Strikes Back, to the Star Wars saga",
@@ -2161,10 +3733,34 @@ O..O.#O.O##O..O
           "col": 3,
           "index": 10
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "V"
+          }
+        ],
         "metadata": {
           "body:line": "105",
           "answer:unprocessed": "PARTV"
-        }
+        },
+        "display": [["text", "The Empire Strikes Back, to the Star Wars saga"]],
+        "direction": "down"
       },
       {
         "body": "Greek letter following 72A",
@@ -2174,10 +3770,34 @@ O..O.#O.O##O..O
           "col": 7,
           "index": 10
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "H"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "106",
           "answer:unprocessed": "THETA"
-        }
+        },
+        "display": [["text", "Greek letter following 72A"]],
+        "direction": "down"
       },
       {
         "body": "Misplace",
@@ -2187,10 +3807,30 @@ O..O.#O.O##O..O
           "col": 4,
           "index": 11
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          }
+        ],
         "metadata": {
           "body:line": "107",
           "answer:unprocessed": "LOSE"
-        }
+        },
+        "display": [["text", "Misplace"]],
+        "direction": "down"
       },
       {
         "body": "Wee boy",
@@ -2200,10 +3840,26 @@ O..O.#O.O##O..O
           "col": 10,
           "index": 11
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "D"
+          }
+        ],
         "metadata": {
           "body:line": "108",
           "answer:unprocessed": "LAD"
-        }
+        },
+        "display": [["text", "Wee boy"]],
+        "direction": "down"
       },
       {
         "body": "Dad to Tommy Pickles",
@@ -2213,10 +3869,26 @@ O..O.#O.O##O..O
           "col": 0,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "U"
+          }
+        ],
         "metadata": {
           "body:line": "109",
           "answer:unprocessed": "STU"
-        }
+        },
+        "display": [["text", "Dad to Tommy Pickles"]],
+        "direction": "down"
       },
       {
         "body": "The only Patrol I trust",
@@ -2226,10 +3898,26 @@ O..O.#O.O##O..O
           "col": 1,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "P"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "W"
+          }
+        ],
         "metadata": {
           "body:line": "110",
           "answer:unprocessed": "PAW"
-        }
+        },
+        "display": [["text", "The only Patrol I trust"]],
+        "direction": "down"
       },
       {
         "body": "Smart savings plan, briefly",
@@ -2239,10 +3927,26 @@ O..O.#O.O##O..O
           "col": 2,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "I"
+          },
+          {
+            "type": "letter",
+            "letter": "R"
+          },
+          {
+            "type": "letter",
+            "letter": "A"
+          }
+        ],
         "metadata": {
           "body:line": "111",
           "answer:unprocessed": "IRA"
-        }
+        },
+        "display": [["text", "Smart savings plan, briefly"]],
+        "direction": "down"
       },
       {
         "body": "Fresh",
@@ -2252,10 +3956,26 @@ O..O.#O.O##O..O
           "col": 6,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "W"
+          }
+        ],
         "metadata": {
           "body:line": "112",
           "answer:unprocessed": "NEW"
-        }
+        },
+        "display": [["text", "Fresh"]],
+        "direction": "down"
       },
       {
         "body": "Breeds such as Chihuahua or Pomeranian",
@@ -2265,10 +3985,26 @@ O..O.#O.O##O..O
           "col": 11,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "T"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "Y"
+          }
+        ],
         "metadata": {
           "body:line": "113",
           "answer:unprocessed": "TOY"
-        }
+        },
+        "display": [["text", "Breeds such as Chihuahua or Pomeranian"]],
+        "direction": "down"
       },
       {
         "body": "Bega behind \"Mambo No. 5\"",
@@ -2278,10 +4014,26 @@ O..O.#O.O##O..O
           "col": 12,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "L"
+          },
+          {
+            "type": "letter",
+            "letter": "O"
+          },
+          {
+            "type": "letter",
+            "letter": "U"
+          }
+        ],
         "metadata": {
           "body:line": "114",
           "answer:unprocessed": "LOU"
-        }
+        },
+        "display": [["text", "Bega behind \"Mambo No. 5\""]],
+        "direction": "down"
       },
       {
         "body": "Aardvark breakfast",
@@ -2291,10 +4043,26 @@ O..O.#O.O##O..O
           "col": 13,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "A"
+          },
+          {
+            "type": "letter",
+            "letter": "N"
+          },
+          {
+            "type": "letter",
+            "letter": "T"
+          }
+        ],
         "metadata": {
           "body:line": "115",
           "answer:unprocessed": "ANT"
-        }
+        },
+        "display": [["text", "Aardvark breakfast"]],
+        "direction": "down"
       },
       {
         "body": "Sonic ___",
@@ -2304,10 +4072,26 @@ O..O.#O.O##O..O
           "col": 14,
           "index": 12
         },
+        "tiles": [
+          {
+            "type": "letter",
+            "letter": "S"
+          },
+          {
+            "type": "letter",
+            "letter": "E"
+          },
+          {
+            "type": "letter",
+            "letter": "Z"
+          }
+        ],
         "metadata": {
           "body:line": "116",
           "answer:unprocessed": "SEZ"
-        }
+        },
+        "display": [["text", "Sonic ___"]],
+        "direction": "down"
       }
     ]
   },
@@ -2592,31 +4376,32 @@ This lib creates `xd` compatible files, but also extends the format in a way tha
 
 - ##### Markdown/HTML style comments
 
-  In markdown you can write `<!--` and `-->` to comment out a section of your code. Our implementation is not _super_ smart:
+In markdown you can write `<!--` and `-->` to comment out a section of your code. Our implementation is not _super_ smart:
 
-  <!-- prettier-ignore -->
-  ```html
-  ## Metadata
+<!-- prettier-ignore -->
+```html
+## Metadata
 
-  <!--  WIP: Maybe it should be called rectangle? -->
+<!--  WIP: Maybe it should be called rectangle? -->
 
-  Title: Square
-  Author: Orta
-  Editor: Orta Therox
+Title: Square
+Author: Orta
+Editor: Orta Therox
 
-  <!--
-  Date: 2021-03-16
-  -->
-  ```
-
-  The key is that a line has to start with `<!--` and eventually the same or another line has to **end** with `-->`.
-
-- ##### BBCode clue syntax
-
-When a clue is written in BBCode, it will be parsed into a JSON representation that can be used to render the clue in a UI. The BBCode syntax is limited and not strictly BBCode, this should be enough to cover most cases though. The syntax is:
-
+<!--
+Date: 2021-03-16
+-->
 ```
-A1. [url=https://github.com/orta]Captain[/url] [b]of[/b] [i]the[/i] ship Pequod ~ AHAB
+
+The key is that a line has to start with `<!--` and eventually the same or another line has to **end** with `-->`.
+
+- ##### Markup in Clues
+
+The [xd spec](https://github.com/century-arcade/xd/blob/master/doc/xd-format.md#clues-section-3) defines markup inside a clue as roughly being "markdown sigil's wrapped in `{` and `}`". We support this format, and will always fill out a key of `markup` which is an array of components. We also add support for links via this syntax: `{@text|url@}`.
+
+<!-- prettier-ignore -->
+```md
+A1. {/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@} ~ AHAB
 ```
 
 Which will add the optional `"bodyMD"` to the clue:
@@ -2624,22 +4409,26 @@ Which will add the optional `"bodyMD"` to the clue:
 ```json
 {
   "answer": "AHAB",
-  "body": "[Captain](https://github.com/orta) **of** /the/ ship Pequod",
-  "bodyMD": [
-    ["link", "Captain", "https://github.com/orta"],
-    ["text", " "],
+  "body": "{/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@}",
+  "display": [
+    ["italics", "Captain"],
+    ["text", ", "],
     ["bold", "of"],
+    ["text", ", "],
+    ["underscore", "the"],
+    ["text", ", ship "],
+    ["strike", "pequod"],
     ["text", " "],
-    ["italics", "the"],
-    ["text", " ship Pequod"]
+    ["link", "see here", "https://mylink.com"]
   ]
 }
 ```
 
-- Italics `/word/` or `/a phrase/` - these have to be at the start of a word to trigger
-- Bold: `**word**` or `**a phrase**`
-- Strike through: `~word~` or `~a phrase~`
-- Link: `[text](url)`
+- Italics: `{/`<key>words</key>`/}`
+- Bold: `{*`<key>words</key>`*}`
+- Strike through: `{-`<key>words</key>`-}` - Note: that we also support `{~`<key>words</key>`~}` because that feels more natural
+- Underline: `{_`<key>words</key>`_}`
+- Link: `{@`<key>words</key>`|<key>url</key>@}`
 
 - ##### Split character
 
@@ -2682,7 +4471,7 @@ We'd be open to a variant of our `JSONToXD` function which produces spec-complia
 
 - `## Design`
 
-  This is our WIP extension to describe the visual aspects of individual cells. The `xd` format uses lowercase letters in the grid to indicate a particular special trait (for example having a circle background.) We are looking at describing a more complex set of visual attributes, and so the puz -> xd parser uses a new section to indicate the design attributes in a manner similar to how rebuses are handled.
+  This is our extension to describe the visual aspects of individual cells. The `xd` format uses lowercase letters in the grid to indicate a particular special trait (for example having a circle background.) We are looking at describing a more complex set of visual attributes, and so the puz -> xd parser uses a new section to indicate the design attributes in a manner similar to how rebuses are handled.
 
   ```md
   ## Design
@@ -2732,21 +4521,8 @@ We'd be open to a variant of our `JSONToXD` function which produces spec-complia
   .....#...##....
   ```
 
-- `## Metapuzzle`
-
-  We'd like a way to describe a final question and a final answer for a puzzle. For example, in alpha-bits above the circles indicate a letter pattern and there could be a way to respond that you got the theme. For example:
-
-  ```md
-  ## Metapuzzle
-
-  How are the words sorted?
-
-  > Alphabetic
-  ```
-
-  Case in the answer should be ignored by engines.
-
 ### Filetypes this lib is open to adding
 
 - http://www.ipuz.org
 - https://www.xwordinfo.com/XPF/ / https://www.xwordinfo.com/JSON/
+- jpz

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,29 +106,32 @@ export interface Position {
 }
 
 // Inline elements to handle when rendering clues
-export type MDClueComponent =
+export type ClueComponentMarkup =
   | [type: "text", text: string]
   | [type: "italics", text: string]
   | [type: "bold", text: string]
   | [type: "strike", text: string]
+  | [type: "underscore", text: string]
   | [type: "link", text: string, to: string]
 
 export interface Clue {
-  /** The "clue" as it were */
+  /** The "clue" as a raw string, sans markup processing */
   body: string
-  /** The body as a set of inline markdown components, not a full markdown processor, but a simple enough heuristic */
-  bodyMD?: MDClueComponent[]
+  /** The body as a set of inline markup components, based on the xd spec, you always want to use this for displaying clues to a user */
+  display: ClueComponentMarkup[]
   /** The number, whether it is across or down is handled back at 'clues' */
   number: number
   /** The string after the "~"" - if the clue has a split character than this will not be included */
   answer: string
   /** Filled in metadata giving the location of the first char on the grid */
   position: Position
-  /** tiles that the clue is composed of */
+  /** Tiles that the clue is composed of */
   tiles: Tile[]
+  /** Somewhat redundant, but also useful reference to whether this clue is was created when looking at acrosses or downs */
+  direction: "across" | "down"
   /** If an answer contains a split character, then this would include the indexes where it was used */
   splits?: number[]
-  /** Duplicating a clue and using a meta suffix (e.g. "A23~Hint. A shot to the heart" )
+  /** Duplicating a clue and using a meta suffix (e.g. "A23 ^Hint. A shot to the heart" )
    * would add to { "hint": " A shot to the heart" } to the metadata.
    */
   metadata?: Record<string, string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xd-crossword-tools",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "description": "Tools for taking different crossword file formats and converting them to xd, and for converting an xd file to useful JSON",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",
@@ -8,7 +8,7 @@
     "test": "jest",
     "docs": "md-magic",
     "build": "tsup index.ts --dts  --format esm,cjs,iife",
-    "prepublishOnly": "pnpm docs && pnpm build",
+    "prepublishOnly": "pnpm build && pnpm docs",
     "type-check": "tsc"
   },
   "repository": {

--- a/tests/output/112921 - speakerboxxx the love below.json
+++ b/tests/output/112921 - speakerboxxx the love below.json
@@ -935,7 +935,14 @@
         "metadata": {
           "body:line": "29",
           "answer:unprocessed": "BLTS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Sandwiches often made with iceberg"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Polymer in pipes",
@@ -962,7 +969,14 @@
         "metadata": {
           "body:line": "30",
           "answer:unprocessed": "PVC"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Polymer in pipes"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Extreme ___ (high-bouncing action sport)",
@@ -993,7 +1007,14 @@
         "metadata": {
           "body:line": "31",
           "answer:unprocessed": "POGO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Extreme ___ (high-bouncing action sport)"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Big name in tomb raiding",
@@ -1024,7 +1045,14 @@
         "metadata": {
           "body:line": "32",
           "answer:unprocessed": "LARA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Big name in tomb raiding"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Time to draw more Bananagrams tiles!\"",
@@ -1055,7 +1083,14 @@
         "metadata": {
           "body:line": "33",
           "answer:unprocessed": "PEEL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Time to draw more Bananagrams tiles!\""
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Faux-French slang for pot",
@@ -1086,7 +1121,14 @@
         "metadata": {
           "body:line": "34",
           "answer:unprocessed": "OUID"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Faux-French slang for pot"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Emotionally honest",
@@ -1117,7 +1159,14 @@
         "metadata": {
           "body:line": "35",
           "answer:unprocessed": "OPEN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Emotionally honest"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Filthy\" money",
@@ -1152,7 +1201,14 @@
         "metadata": {
           "body:line": "36",
           "answer:unprocessed": "LUCRE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Filthy\" money"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The feminine ___ to write clues referencing memes",
@@ -1183,7 +1239,14 @@
         "metadata": {
           "body:line": "37",
           "answer:unprocessed": "URGE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The feminine ___ to write clues referencing memes"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Black Panther\" star",
@@ -1247,7 +1310,14 @@
         "metadata": {
           "body:line": "38",
           "answer:unprocessed": "CHADWICKBOSEMAN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Black Panther\" star"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Collection of drums",
@@ -1274,7 +1344,14 @@
         "metadata": {
           "body:line": "39",
           "answer:unprocessed": "KIT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Collection of drums"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Pariah\" director Dee",
@@ -1305,7 +1382,14 @@
         "metadata": {
           "body:line": "40",
           "answer:unprocessed": "REES"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Pariah\" director Dee"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Like small talk",
@@ -1336,7 +1420,14 @@
         "metadata": {
           "body:line": "41",
           "answer:unprocessed": "IDLE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Like small talk"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Mischievous acknowledgment from across the room",
@@ -1375,7 +1466,14 @@
         "metadata": {
           "body:line": "42",
           "answer:unprocessed": "SLYNOD"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Mischievous acknowledgment from across the room"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "It goes over your head",
@@ -1422,7 +1520,14 @@
         "metadata": {
           "body:line": "43",
           "answer:unprocessed": "AIRSPACE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "It goes over your head"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Shoo!\"",
@@ -1449,7 +1554,14 @@
         "metadata": {
           "body:line": "44",
           "answer:unprocessed": "OUT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Shoo!\""
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Comprehensive range",
@@ -1480,7 +1592,14 @@
         "metadata": {
           "body:line": "45",
           "answer:unprocessed": "ATOZ"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Comprehensive range"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Shabu-shabu noodles",
@@ -1511,7 +1630,14 @@
         "metadata": {
           "body:line": "46",
           "answer:unprocessed": "UDON"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Shabu-shabu noodles"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Father of bacteriology",
@@ -1554,7 +1680,14 @@
         "metadata": {
           "body:line": "47",
           "answer:unprocessed": "PASTEUR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Father of bacteriology"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Like a delinquent sentry, maybe",
@@ -1597,7 +1730,14 @@
         "metadata": {
           "body:line": "48",
           "answer:unprocessed": "NAPPING"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Like a delinquent sentry, maybe"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Maker of Swift laptops",
@@ -1628,7 +1768,14 @@
         "metadata": {
           "body:line": "49",
           "answer:unprocessed": "ACER"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Maker of Swift laptops"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Scotch samples",
@@ -1659,7 +1806,14 @@
         "metadata": {
           "body:line": "50",
           "answer:unprocessed": "SIPS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Scotch samples"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Animal in that one graphic showing the evolution of humans",
@@ -1686,7 +1840,14 @@
         "metadata": {
           "body:line": "51",
           "answer:unprocessed": "APE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Animal in that one graphic showing the evolution of humans"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Dressing station",
@@ -1733,7 +1894,14 @@
         "metadata": {
           "body:line": "52",
           "answer:unprocessed": "SALADBAR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Dressing station"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Milano who was also in last week's grid",
@@ -1772,7 +1940,14 @@
         "metadata": {
           "body:line": "53",
           "answer:unprocessed": "ALYSSA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Milano who was also in last week's grid"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Assuming that's the case...\"",
@@ -1803,7 +1978,14 @@
         "metadata": {
           "body:line": "54",
           "answer:unprocessed": "IFSO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Assuming that's the case...\""
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___ of Mull",
@@ -1834,7 +2016,14 @@
         "metadata": {
           "body:line": "55",
           "answer:unprocessed": "ISLE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "___ of Mull"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Put money into",
@@ -1861,7 +2050,14 @@
         "metadata": {
           "body:line": "56",
           "answer:unprocessed": "FED"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Put money into"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"Something bothering you?\"",
@@ -1925,7 +2121,14 @@
         "metadata": {
           "body:line": "57",
           "answer:unprocessed": "WHATSONYOURMIND"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Something bothering you?\""
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Academic regalia component",
@@ -1956,7 +2159,14 @@
         "metadata": {
           "body:line": "58",
           "answer:unprocessed": "ROBE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Academic regalia component"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Seemingly unbridgeable gap",
@@ -1991,7 +2201,14 @@
         "metadata": {
           "body:line": "59",
           "answer:unprocessed": "CHASM"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Seemingly unbridgeable gap"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Down-under part, Down Under",
@@ -2022,7 +2239,14 @@
         "metadata": {
           "body:line": "60",
           "answer:unprocessed": "ARSE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Down-under part, Down Under"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Baby boo-boo",
@@ -2053,7 +2277,14 @@
         "metadata": {
           "body:line": "61",
           "answer:unprocessed": "OWIE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Baby boo-boo"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Someone you should never meet",
@@ -2084,7 +2315,14 @@
         "metadata": {
           "body:line": "62",
           "answer:unprocessed": "HERO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Someone you should never meet"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "App downloader",
@@ -2115,7 +2353,14 @@
         "metadata": {
           "body:line": "63",
           "answer:unprocessed": "USER"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "App downloader"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Stain on a reputation",
@@ -2146,7 +2391,14 @@
         "metadata": {
           "body:line": "64",
           "answer:unprocessed": "BLOT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Stain on a reputation"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Terminus",
@@ -2173,7 +2425,14 @@
         "metadata": {
           "body:line": "65",
           "answer:unprocessed": "END"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Terminus"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "\"That's true\"",
@@ -2204,7 +2463,14 @@
         "metadata": {
           "body:line": "66",
           "answer:unprocessed": "ITIS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"That's true\""
+          ]
+        ],
+        "direction": "across"
       }
     ],
     "down": [
@@ -2245,7 +2511,14 @@
         "metadata": {
           "body:line": "68",
           "answer:unprocessed": "BLOCKS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "This puzzle has 43 of them"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Walt Disney Concert Hall orchestra, casually",
@@ -2284,7 +2557,14 @@
         "metadata": {
           "body:line": "69",
           "answer:unprocessed": "LAPHIL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Walt Disney Concert Hall orchestra, casually"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Catchphrase for Donna and Tom on \"Parks and Rec\"",
@@ -2343,7 +2623,14 @@
         "metadata": {
           "body:line": "70",
           "answer:unprocessed": "TREATYOSELF"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Catchphrase for Donna and Tom on \"Parks and Rec\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Plentiful substance in 2021's \"Dune\"",
@@ -2374,7 +2661,14 @@
         "metadata": {
           "body:line": "71",
           "answer:unprocessed": "SAND"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Plentiful substance in 2021's \"Dune\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Eats like a bird",
@@ -2417,7 +2711,14 @@
         "metadata": {
           "body:line": "72",
           "answer:unprocessed": "PECKSAT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Eats like a bird"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Talkative",
@@ -2449,7 +2750,14 @@
         "metadata": {
           "body:line": "73",
           "answer:unprocessed": "VERBOSE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Talkative"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Nickname that omits \"ent\"",
@@ -2480,7 +2788,14 @@
         "metadata": {
           "body:line": "74",
           "answer:unprocessed": "CLEM"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Nickname that omits \"ent\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Classic canine plush toy",
@@ -2535,7 +2850,14 @@
         "metadata": {
           "body:line": "75",
           "answer:unprocessed": "POUNDPUPPY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Classic canine plush toy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"___ American Cousin\" (\"Other than that, Mrs. Lincoln, did you enjoy the play?\" play)",
@@ -2562,7 +2884,14 @@
         "metadata": {
           "body:line": "76",
           "answer:unprocessed": "OUR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"___ American Cousin\" (\"Other than that, Mrs. Lincoln, did you enjoy the play?\" play)"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Part of a tour",
@@ -2589,7 +2918,14 @@
         "metadata": {
           "body:line": "77",
           "answer:unprocessed": "GIG"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Part of a tour"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"___ to Freedom\" (2021 ABBA song)",
@@ -2616,7 +2952,14 @@
         "metadata": {
           "body:line": "78",
           "answer:unprocessed": "ODE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"___ to Freedom\" (2021 ABBA song)"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Purplish color",
@@ -2647,7 +2990,14 @@
         "metadata": {
           "body:line": "79",
           "answer:unprocessed": "PUCE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Purplish color"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Stretched the truth",
@@ -2678,7 +3028,14 @@
         "metadata": {
           "body:line": "80",
           "answer:unprocessed": "LIED"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Stretched the truth"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Did some calligraphy",
@@ -2713,7 +3070,14 @@
         "metadata": {
           "body:line": "81",
           "answer:unprocessed": "WROTE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Did some calligraphy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Systems that many Silicon Valley types are obsessed with",
@@ -2740,7 +3104,14 @@
         "metadata": {
           "body:line": "82",
           "answer:unprocessed": "AIS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Systems that many Silicon Valley types are obsessed with"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Quaint rule of chivalry",
@@ -2799,7 +3170,14 @@
         "metadata": {
           "body:line": "83",
           "answer:unprocessed": "LADIESFIRST"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Quaint rule of chivalry"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Certain social sci",
@@ -2830,7 +3208,14 @@
         "metadata": {
           "body:line": "84",
           "answer:unprocessed": "ECON"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Certain social sci"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Splenda alternative",
@@ -2885,7 +3270,14 @@
         "metadata": {
           "body:line": "85",
           "answer:unprocessed": "NUTRASWEET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Splenda alternative"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Particles that get exchanged",
@@ -2916,7 +3308,14 @@
         "metadata": {
           "body:line": "86",
           "answer:unprocessed": "IONS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Particles that get exchanged"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Wu-Tang Clan member",
@@ -2943,7 +3342,14 @@
         "metadata": {
           "body:line": "87",
           "answer:unprocessed": "RZA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Wu-Tang Clan member"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "An official language of the EU",
@@ -2970,7 +3376,14 @@
         "metadata": {
           "body:line": "88",
           "answer:unprocessed": "ENG"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "An official language of the EU"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"Carmen\" carmen (for this clue you have to know that \"carmen\" is Latin for \"song\" and roll with the random bit of Latin)",
@@ -3001,7 +3414,14 @@
         "metadata": {
           "body:line": "89",
           "answer:unprocessed": "ARIA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Carmen\" carmen (for this clue you have to know that \"carmen\" is Latin for \"song\" and roll with the random bit of Latin)"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Faux ___",
@@ -3028,7 +3448,14 @@
         "metadata": {
           "body:line": "90",
           "answer:unprocessed": "PAS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Faux ___"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Berry promoted as a health food",
@@ -3059,7 +3486,14 @@
         "metadata": {
           "body:line": "91",
           "answer:unprocessed": "ACAI"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Berry promoted as a health food"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Holder of backup files, often",
@@ -3086,7 +3520,14 @@
         "metadata": {
           "body:line": "92",
           "answer:unprocessed": "USB"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Holder of backup files, often"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Not as ruddy",
@@ -3121,7 +3562,14 @@
         "metadata": {
           "body:line": "93",
           "answer:unprocessed": "PALER"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Not as ruddy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Place for convicts to exercise",
@@ -3165,7 +3613,14 @@
         "metadata": {
           "body:line": "94",
           "answer:unprocessed": "PRISONYARD"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Place for convicts to exercise"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Facepalming exclamation",
@@ -3192,7 +3647,14 @@
         "metadata": {
           "body:line": "95",
           "answer:unprocessed": "DOH"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Facepalming exclamation"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Grad",
@@ -3223,7 +3685,14 @@
         "metadata": {
           "body:line": "96",
           "answer:unprocessed": "ALUM"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Grad"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Dojo teacher",
@@ -3262,7 +3731,14 @@
         "metadata": {
           "body:line": "97",
           "answer:unprocessed": "SENSEI"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Dojo teacher"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Venomous serpents",
@@ -3301,7 +3777,14 @@
         "metadata": {
           "body:line": "98",
           "answer:unprocessed": "ADDERS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Venomous serpents"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Not great, not terrible",
@@ -3332,7 +3815,14 @@
         "metadata": {
           "body:line": "99",
           "answer:unprocessed": "SOSO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Not great, not terrible"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Unrequited love feeling",
@@ -3363,7 +3853,14 @@
         "metadata": {
           "body:line": "100",
           "answer:unprocessed": "ACHE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Unrequited love feeling"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"What happened next was...\"",
@@ -3394,7 +3891,14 @@
         "metadata": {
           "body:line": "101",
           "answer:unprocessed": "THEN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"What happened next was...\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Island whose Big Bog is one of the world's wettest places",
@@ -3425,7 +3929,14 @@
         "metadata": {
           "body:line": "102",
           "answer:unprocessed": "MAUI"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Island whose Big Bog is one of the world's wettest places"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Way overcharge",
@@ -3452,7 +3963,14 @@
         "metadata": {
           "body:line": "103",
           "answer:unprocessed": "ROB"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Way overcharge"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"Guardians of Ga'Hoole\" bird",
@@ -3479,7 +3997,14 @@
         "metadata": {
           "body:line": "104",
           "answer:unprocessed": "OWL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Guardians of Ga'Hoole\" bird"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Link in ___",
@@ -3506,7 +4031,14 @@
         "metadata": {
           "body:line": "105",
           "answer:unprocessed": "BIO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Link in ___"
+          ]
+        ],
+        "direction": "down"
       }
     ]
   },

--- a/tests/output/alpha-bits.json
+++ b/tests/output/alpha-bits.json
@@ -928,7 +928,14 @@
         "metadata": {
           "body:line": "28",
           "answer:unprocessed": "AHAB"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Captain of the Pequod"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Food for second chance chewing",
@@ -955,7 +962,14 @@
         "metadata": {
           "body:line": "29",
           "answer:unprocessed": "CUD"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Food for second chance chewing"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Font feature",
@@ -990,7 +1004,14 @@
         "metadata": {
           "body:line": "30",
           "answer:unprocessed": "SERIF"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Font feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Palindromic address to a female",
@@ -1025,7 +1046,14 @@
         "metadata": {
           "body:line": "31",
           "answer:unprocessed": "MADAM"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Palindromic address to a female"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___ Way You Want It",
@@ -1052,7 +1080,14 @@
         "metadata": {
           "body:line": "32",
           "answer:unprocessed": "ANY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "___ Way You Want It"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Place often described as humble",
@@ -1087,7 +1122,14 @@
         "metadata": {
           "body:line": "33",
           "answer:unprocessed": "ABODE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Place often described as humble"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Flat two dimensional surface in geometry",
@@ -1122,7 +1164,14 @@
         "metadata": {
           "body:line": "34",
           "answer:unprocessed": "PLANE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Flat two dimensional surface in geometry"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Grim homophone of 7D",
@@ -1149,7 +1198,14 @@
         "metadata": {
           "body:line": "35",
           "answer:unprocessed": "DIE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Grim homophone of 7D"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Off",
@@ -1184,7 +1240,14 @@
         "metadata": {
           "body:line": "36",
           "answer:unprocessed": "NOTON"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Off"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Heading for some lists",
@@ -1215,7 +1278,14 @@
         "metadata": {
           "body:line": "37",
           "answer:unprocessed": "TODO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Heading for some lists"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Kanye West is famous for his",
@@ -1242,7 +1312,14 @@
         "metadata": {
           "body:line": "38",
           "answer:unprocessed": "EGO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Kanye West is famous for his"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Laceration",
@@ -1273,7 +1350,14 @@
         "metadata": {
           "body:line": "39",
           "answer:unprocessed": "GASH"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Laceration"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Alias of Twitch star Richard Tyler Blevins",
@@ -1308,7 +1392,14 @@
         "metadata": {
           "body:line": "40",
           "answer:unprocessed": "NINJA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Alias of Twitch star Richard Tyler Blevins"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Capsize",
@@ -1339,7 +1430,14 @@
         "metadata": {
           "body:line": "41",
           "answer:unprocessed": "KEEL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Capsize"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Piece of clothing or print",
@@ -1382,7 +1480,14 @@
         "metadata": {
           "body:line": "42",
           "answer:unprocessed": "ARTICLE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Piece of clothing or print"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Evangelical school in Tulsa, OK",
@@ -1409,7 +1514,14 @@
         "metadata": {
           "body:line": "43",
           "answer:unprocessed": "ORU"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Evangelical school in Tulsa, OK"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___-eyed",
@@ -1436,7 +1548,14 @@
         "metadata": {
           "body:line": "44",
           "answer:unprocessed": "DOE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "___-eyed"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Annual",
@@ -1475,7 +1594,14 @@
         "metadata": {
           "body:line": "45",
           "answer:unprocessed": "YEARLY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Annual"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The stamp with the upside down airplane is a famous one",
@@ -1522,7 +1648,14 @@
         "metadata": {
           "body:line": "46",
           "answer:unprocessed": "MISPRINT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The stamp with the upside down airplane is a famous one"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "With 42A and Marcus, a luxury department store chain",
@@ -1549,7 +1682,14 @@
         "metadata": {
           "body:line": "47",
           "answer:unprocessed": "NEI"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "With 42A and Marcus, a luxury department store chain"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "41A continued",
@@ -1576,7 +1716,14 @@
         "metadata": {
           "body:line": "48",
           "answer:unprocessed": "MAN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "41A continued"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lush",
@@ -1603,7 +1750,14 @@
         "metadata": {
           "body:line": "49",
           "answer:unprocessed": "SOT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Lush"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The Mayan one ended in 2012",
@@ -1650,7 +1804,14 @@
         "metadata": {
           "body:line": "50",
           "answer:unprocessed": "CALENDAR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The Mayan one ended in 2012"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What a child often does to their shoes",
@@ -1689,7 +1850,14 @@
         "metadata": {
           "body:line": "51",
           "answer:unprocessed": "RETIES"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "What a child often does to their shoes"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Vanilla ___",
@@ -1716,7 +1884,14 @@
         "metadata": {
           "body:line": "52",
           "answer:unprocessed": "ICE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Vanilla ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Maligned cigarette ingredient",
@@ -1743,7 +1918,14 @@
         "metadata": {
           "body:line": "53",
           "answer:unprocessed": "TAR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Maligned cigarette ingredient"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Frequent cause for a new tire",
@@ -1786,7 +1968,14 @@
         "metadata": {
           "body:line": "54",
           "answer:unprocessed": "POTHOLE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Frequent cause for a new tire"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Los Angeles heavy metal act",
@@ -1817,7 +2006,14 @@
         "metadata": {
           "body:line": "55",
           "answer:unprocessed": "OTEP"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Los Angeles heavy metal act"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Bldgs. such as the Googleplex",
@@ -1852,7 +2048,14 @@
         "metadata": {
           "body:line": "56",
           "answer:unprocessed": "HQTRS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Bldgs. such as the Googleplex"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "A fit of irritation",
@@ -1883,7 +2086,14 @@
         "metadata": {
           "body:line": "57",
           "answer:unprocessed": "SNIT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "A fit of irritation"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lead-in to American or day",
@@ -1910,7 +2120,14 @@
         "metadata": {
           "body:line": "58",
           "answer:unprocessed": "ALL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Lead-in to American or day"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What Pokémon do at a Pokémon Center",
@@ -1941,7 +2158,14 @@
         "metadata": {
           "body:line": "59",
           "answer:unprocessed": "HEAL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "What Pokémon do at a Pokémon Center"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nixon's vice",
@@ -1976,7 +2200,14 @@
         "metadata": {
           "body:line": "60",
           "answer:unprocessed": "SPIRO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Nixon's vice"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nothing but ___",
@@ -2003,7 +2234,14 @@
         "metadata": {
           "body:line": "61",
           "answer:unprocessed": "NET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Nothing but ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "One with the world on his shoulders",
@@ -2038,7 +2276,14 @@
         "metadata": {
           "body:line": "62",
           "answer:unprocessed": "ATLAS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "One with the world on his shoulders"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Filled pastries",
@@ -2073,7 +2318,14 @@
         "metadata": {
           "body:line": "63",
           "answer:unprocessed": "TARTS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Filled pastries"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Age, in Milan",
@@ -2100,7 +2352,14 @@
         "metadata": {
           "body:line": "64",
           "answer:unprocessed": "ETA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Age, in Milan"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lorna ___, novel or cookie",
@@ -2135,7 +2394,14 @@
         "metadata": {
           "body:line": "65",
           "answer:unprocessed": "DOONE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Lorna ___, novel or cookie"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Electrocardiogram readout feature",
@@ -2170,7 +2436,14 @@
         "metadata": {
           "body:line": "66",
           "answer:unprocessed": "UWAVE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Electrocardiogram readout feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Hip slang for records",
@@ -2197,7 +2470,14 @@
         "metadata": {
           "body:line": "67",
           "answer:unprocessed": "WAX"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Hip slang for records"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Yiddish for a foolish person",
@@ -2228,7 +2508,14 @@
         "metadata": {
           "body:line": "68",
           "answer:unprocessed": "YUTZ"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Yiddish for a foolish person"
+          ]
+        ],
+        "direction": "across"
       }
     ],
     "down": [
@@ -2257,7 +2544,14 @@
         "metadata": {
           "body:line": "70",
           "answer:unprocessed": "AMP"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Pc. of concert gear"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "AI antagonist of 2001",
@@ -2284,7 +2578,14 @@
         "metadata": {
           "body:line": "71",
           "answer:unprocessed": "HAL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "AI antagonist of 2001"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Programming pioneer Lovelace",
@@ -2311,7 +2612,14 @@
         "metadata": {
           "body:line": "72",
           "answer:unprocessed": "ADA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Programming pioneer Lovelace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Prohibit",
@@ -2338,7 +2646,14 @@
         "metadata": {
           "body:line": "73",
           "answer:unprocessed": "BAN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Prohibit"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of person to routinely carry a club",
@@ -2377,7 +2692,14 @@
         "metadata": {
           "body:line": "74",
           "answer:unprocessed": "CADDIE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Type of person to routinely carry a club"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "State of the ___ Address",
@@ -2412,7 +2734,14 @@
         "metadata": {
           "body:line": "75",
           "answer:unprocessed": "UNION"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "State of the ___ Address"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Colorful homophone of 18A",
@@ -2439,7 +2768,14 @@
         "metadata": {
           "body:line": "76",
           "answer:unprocessed": "DYE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Colorful homophone of 18A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Snitched",
@@ -2470,7 +2806,14 @@
         "metadata": {
           "body:line": "77",
           "answer:unprocessed": "SANG"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Snitched"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Kindle fare",
@@ -2505,7 +2848,14 @@
         "metadata": {
           "body:line": "78",
           "answer:unprocessed": "EBOOK"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Kindle fare"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Decayed matter",
@@ -2532,7 +2882,14 @@
         "metadata": {
           "body:line": "79",
           "answer:unprocessed": "ROT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Decayed matter"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of response you hope to get at the altar",
@@ -2559,7 +2916,14 @@
         "metadata": {
           "body:line": "80",
           "answer:unprocessed": "IDO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Type of response you hope to get at the altar"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Peat-accumulating wetland",
@@ -2586,7 +2950,14 @@
         "metadata": {
           "body:line": "81",
           "answer:unprocessed": "FEN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Peat-accumulating wetland"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The ___, NY art museum",
@@ -2613,7 +2984,14 @@
         "metadata": {
           "body:line": "82",
           "answer:unprocessed": "MET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The ___, NY art museum"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "___Fans",
@@ -2644,7 +3022,14 @@
         "metadata": {
           "body:line": "83",
           "answer:unprocessed": "ONLY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "___Fans"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Friends, Romans, countrymen, lend me your...",
@@ -2675,7 +3060,14 @@
         "metadata": {
           "body:line": "84",
           "answer:unprocessed": "EARS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Friends, Romans, countrymen, lend me your..."
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"Friend of Dorothy\"",
@@ -2702,7 +3094,14 @@
         "metadata": {
           "body:line": "85",
           "answer:unprocessed": "GAY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "\"Friend of Dorothy\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "We ___ the Champions",
@@ -2729,7 +3128,14 @@
         "metadata": {
           "body:line": "86",
           "answer:unprocessed": "ARE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "We ___ the Champions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Father of Spider-Man",
@@ -2772,7 +3178,14 @@
         "metadata": {
           "body:line": "87",
           "answer:unprocessed": "STANLEE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Father of Spider-Man"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "What a certain applicant becomes",
@@ -2807,7 +3220,14 @@
         "metadata": {
           "body:line": "88",
           "answer:unprocessed": "HIREE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "What a certain applicant becomes"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Connect",
@@ -2838,7 +3258,14 @@
         "metadata": {
           "body:line": "89",
           "answer:unprocessed": "JOIN"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Connect"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Particular form of a published text",
@@ -2881,7 +3308,14 @@
         "metadata": {
           "body:line": "90",
           "answer:unprocessed": "EDITION"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Particular form of a published text"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Suffix at the end of all of Eevee's evolutions",
@@ -2908,7 +3342,14 @@
         "metadata": {
           "body:line": "91",
           "answer:unprocessed": "EON"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Suffix at the end of all of Eevee's evolutions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Live and ___ Die",
@@ -2935,7 +3376,14 @@
         "metadata": {
           "body:line": "92",
           "answer:unprocessed": "LET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Live and ___ Die"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Famous Eastwood whose name became a famous Gorillaz song",
@@ -2970,7 +3418,14 @@
         "metadata": {
           "body:line": "93",
           "answer:unprocessed": "CLINT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Famous Eastwood whose name became a famous Gorillaz song"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Unexpected result in a sporting competition",
@@ -3005,7 +3460,14 @@
         "metadata": {
           "body:line": "94",
           "answer:unprocessed": "UPSET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Unexpected result in a sporting competition"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Disfigure",
@@ -3032,7 +3494,14 @@
         "metadata": {
           "body:line": "95",
           "answer:unprocessed": "MAR"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Disfigure"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "David Lee and Tim",
@@ -3067,7 +3536,14 @@
         "metadata": {
           "body:line": "96",
           "answer:unprocessed": "ROTHS"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "David Lee and Tim"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Luxury watch collection by Garmin",
@@ -3098,7 +3574,14 @@
         "metadata": {
           "body:line": "97",
           "answer:unprocessed": "MARQ"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Luxury watch collection by Garmin"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Top dog in an IT org",
@@ -3125,7 +3608,14 @@
         "metadata": {
           "body:line": "98",
           "answer:unprocessed": "CIO"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Top dog in an IT org"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sister ___",
@@ -3152,7 +3642,14 @@
         "metadata": {
           "body:line": "99",
           "answer:unprocessed": "ACT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Sister ___"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Author Roald",
@@ -3183,7 +3680,14 @@
         "metadata": {
           "body:line": "100",
           "answer:unprocessed": "DAHL"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Author Roald"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Civil rights activist Parks",
@@ -3214,7 +3718,14 @@
         "metadata": {
           "body:line": "101",
           "answer:unprocessed": "ROSA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Civil rights activist Parks"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "An additional name that could be part of 40D's clue",
@@ -3241,7 +3752,14 @@
         "metadata": {
           "body:line": "102",
           "answer:unprocessed": "ELI"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "An additional name that could be part of 40D's clue"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Director's domain",
@@ -3268,7 +3786,14 @@
         "metadata": {
           "body:line": "103",
           "answer:unprocessed": "SET"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Director's domain"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of income to go in a 401k",
@@ -3307,7 +3832,14 @@
         "metadata": {
           "body:line": "104",
           "answer:unprocessed": "PRETAX"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Type of income to go in a 401k"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The Empire Strikes Back, to the Star Wars saga",
@@ -3342,7 +3874,14 @@
         "metadata": {
           "body:line": "105",
           "answer:unprocessed": "PARTV"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The Empire Strikes Back, to the Star Wars saga"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Greek letter following 72A",
@@ -3377,7 +3916,14 @@
         "metadata": {
           "body:line": "106",
           "answer:unprocessed": "THETA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Greek letter following 72A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Misplace",
@@ -3408,7 +3954,14 @@
         "metadata": {
           "body:line": "107",
           "answer:unprocessed": "LOSE"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Misplace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Wee boy",
@@ -3435,7 +3988,14 @@
         "metadata": {
           "body:line": "108",
           "answer:unprocessed": "LAD"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Wee boy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Dad to Tommy Pickles",
@@ -3462,7 +4022,14 @@
         "metadata": {
           "body:line": "109",
           "answer:unprocessed": "STU"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Dad to Tommy Pickles"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The only Patrol I trust",
@@ -3489,7 +4056,14 @@
         "metadata": {
           "body:line": "110",
           "answer:unprocessed": "PAW"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "The only Patrol I trust"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Smart savings plan, briefly",
@@ -3516,7 +4090,14 @@
         "metadata": {
           "body:line": "111",
           "answer:unprocessed": "IRA"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Smart savings plan, briefly"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Fresh",
@@ -3543,7 +4124,14 @@
         "metadata": {
           "body:line": "112",
           "answer:unprocessed": "NEW"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Fresh"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Breeds such as Chihuahua or Pomeranian",
@@ -3570,7 +4158,14 @@
         "metadata": {
           "body:line": "113",
           "answer:unprocessed": "TOY"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Breeds such as Chihuahua or Pomeranian"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Bega behind \"Mambo No. 5\"",
@@ -3597,7 +4192,14 @@
         "metadata": {
           "body:line": "114",
           "answer:unprocessed": "LOU"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Bega behind \"Mambo No. 5\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Aardvark breakfast",
@@ -3624,7 +4226,14 @@
         "metadata": {
           "body:line": "115",
           "answer:unprocessed": "ANT"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Aardvark breakfast"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sonic ___",
@@ -3651,7 +4260,14 @@
         "metadata": {
           "body:line": "116",
           "answer:unprocessed": "SEZ"
-        }
+        },
+        "display": [
+          [
+            "text",
+            "Sonic ___"
+          ]
+        ],
+        "direction": "down"
       }
     ]
   },

--- a/tests/output/fail_bad_clue.xd.json
+++ b/tests/output/fail_bad_clue.xd.json
@@ -921,7 +921,14 @@
             "type": "letter",
             "letter": "B"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Captain of the Pequod"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Food for second chance chewing",
@@ -944,7 +951,14 @@
             "type": "letter",
             "letter": "D"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Food for second chance chewing"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Font feature",
@@ -975,7 +989,14 @@
             "type": "letter",
             "letter": "F"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Font feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___ Way You Want It",
@@ -998,7 +1019,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___ Way You Want It"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Place often described as humble",
@@ -1029,7 +1057,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Place often described as humble"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Flat two dimensional surface in geometry",
@@ -1060,7 +1095,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Flat two dimensional surface in geometry"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Grim homophone of 7D",
@@ -1083,7 +1125,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Grim homophone of 7D"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Off",
@@ -1114,7 +1163,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Off"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Heading for some lists",
@@ -1141,7 +1197,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Heading for some lists"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Kanye West is famous for his",
@@ -1164,7 +1227,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Kanye West is famous for his"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Laceration",
@@ -1191,7 +1261,14 @@
             "type": "letter",
             "letter": "H"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Laceration"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Alias of Twitch star Richard Tyler Blevins",
@@ -1222,7 +1299,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Alias of Twitch star Richard Tyler Blevins"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Capsize",
@@ -1249,7 +1333,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Capsize"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Piece of clothing or print",
@@ -1288,7 +1379,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Piece of clothing or print"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Evangelical school in Tulsa, OK",
@@ -1311,7 +1409,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Evangelical school in Tulsa, OK"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___-eyed",
@@ -1334,7 +1439,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___-eyed"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Annual",
@@ -1369,7 +1481,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Annual"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The stamp with the upside down airplane is a famous one",
@@ -1412,7 +1531,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The stamp with the upside down airplane is a famous one"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "With 42A and Marcus, a luxury department store chain",
@@ -1435,7 +1561,14 @@
             "type": "letter",
             "letter": "I"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "With 42A and Marcus, a luxury department store chain"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "41A continued",
@@ -1458,7 +1591,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "41A continued"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lush",
@@ -1481,7 +1621,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lush"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The Mayan one ended in 2012",
@@ -1524,7 +1671,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The Mayan one ended in 2012"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What a child often does to their shoes",
@@ -1559,7 +1713,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What a child often does to their shoes"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Vanilla ___",
@@ -1582,7 +1743,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Vanilla ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Maligned cigarette ingredient",
@@ -1605,7 +1773,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Maligned cigarette ingredient"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Frequent cause for a new tire",
@@ -1644,7 +1819,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Frequent cause for a new tire"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Los Angeles heavy metal act",
@@ -1671,7 +1853,14 @@
             "type": "letter",
             "letter": "P"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Los Angeles heavy metal act"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Bldgs. such as the Googleplex",
@@ -1702,7 +1891,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Bldgs. such as the Googleplex"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "A fit of irritation",
@@ -1729,7 +1925,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "A fit of irritation"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lead-in to American or day",
@@ -1752,7 +1955,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lead-in to American or day"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What Pokémon do at a Pokémon Center",
@@ -1779,7 +1989,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What Pokémon do at a Pokémon Center"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nixon's vice",
@@ -1810,7 +2027,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Nixon's vice"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nothing but ___",
@@ -1833,7 +2057,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Nothing but ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "One with the world on his shoulders",
@@ -1864,7 +2095,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "One with the world on his shoulders"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Filled pastries",
@@ -1895,7 +2133,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Filled pastries"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Age, in Milan",
@@ -1918,7 +2163,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Age, in Milan"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lorna ___, novel or cookie",
@@ -1949,7 +2201,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lorna ___, novel or cookie"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Electrocardiogram readout feature",
@@ -1980,7 +2239,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Electrocardiogram readout feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Hip slang for records",
@@ -2003,7 +2269,14 @@
             "type": "letter",
             "letter": "X"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Hip slang for records"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Yiddish for a foolish person",
@@ -2030,7 +2303,14 @@
             "type": "letter",
             "letter": "Z"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Yiddish for a foolish person"
+          ]
+        ],
+        "direction": "across"
       }
     ],
     "down": [
@@ -2055,7 +2335,14 @@
             "type": "letter",
             "letter": "P"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Pc. of concert gear"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "AI antagonist of 2001",
@@ -2078,7 +2365,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "AI antagonist of 2001"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Programming pioneer Lovelace",
@@ -2101,7 +2395,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Programming pioneer Lovelace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Prohibit",
@@ -2124,7 +2425,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Prohibit"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of person to routinely carry a club",
@@ -2159,7 +2467,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of person to routinely carry a club"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "State of the ___ Address",
@@ -2190,7 +2505,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "State of the ___ Address"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Colorful homophone of 18A",
@@ -2213,7 +2535,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Colorful homophone of 18A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Snitched",
@@ -2240,7 +2569,14 @@
             "type": "letter",
             "letter": "G"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Snitched"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Kindle fare",
@@ -2271,7 +2607,14 @@
             "type": "letter",
             "letter": "K"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Kindle fare"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Decayed matter",
@@ -2294,7 +2637,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Decayed matter"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of response you hope to get at the altar",
@@ -2317,7 +2667,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of response you hope to get at the altar"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Peat-accumulating wetland",
@@ -2340,7 +2697,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Peat-accumulating wetland"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The ___, NY art museum",
@@ -2363,7 +2727,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The ___, NY art museum"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "___Fans",
@@ -2390,7 +2761,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___Fans"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Friends, Romans, countrymen, lend me your...",
@@ -2417,7 +2795,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Friends, Romans, countrymen, lend me your..."
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"Friend of Dorothy\"",
@@ -2440,7 +2825,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "\"Friend of Dorothy\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "We ___ the Champions",
@@ -2463,7 +2855,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "We ___ the Champions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Father of Spider-Man",
@@ -2502,7 +2901,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Father of Spider-Man"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "What a certain applicant becomes",
@@ -2533,7 +2939,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What a certain applicant becomes"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Connect",
@@ -2560,7 +2973,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Connect"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Particular form of a published text",
@@ -2599,7 +3019,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Particular form of a published text"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Suffix at the end of all of Eevee's evolutions",
@@ -2622,7 +3049,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Suffix at the end of all of Eevee's evolutions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Live and ___ Die",
@@ -2645,7 +3079,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Live and ___ Die"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Famous Eastwood whose name became a famous Gorillaz song",
@@ -2676,7 +3117,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Famous Eastwood whose name became a famous Gorillaz song"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Unexpected result in a sporting competition",
@@ -2707,7 +3155,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Unexpected result in a sporting competition"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Disfigure",
@@ -2730,7 +3185,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Disfigure"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "David Lee and Tim",
@@ -2761,7 +3223,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "David Lee and Tim"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Luxury watch collection by Garmin",
@@ -2788,7 +3257,14 @@
             "type": "letter",
             "letter": "Q"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Luxury watch collection by Garmin"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Top dog in an IT org",
@@ -2811,7 +3287,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Top dog in an IT org"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sister ___",
@@ -2834,7 +3317,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Sister ___"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Author Roald",
@@ -2861,7 +3351,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Author Roald"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Civil rights activist Parks",
@@ -2888,7 +3385,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Civil rights activist Parks"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "An additional name that could be part of 40D's clue",
@@ -2911,7 +3415,14 @@
             "type": "letter",
             "letter": "I"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "An additional name that could be part of 40D's clue"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Director's domain",
@@ -2934,7 +3445,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Director's domain"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of income to go in a 401k",
@@ -2969,7 +3487,14 @@
             "type": "letter",
             "letter": "X"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of income to go in a 401k"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The Empire Strikes Back, to the Star Wars saga",
@@ -3000,7 +3525,14 @@
             "type": "letter",
             "letter": "V"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The Empire Strikes Back, to the Star Wars saga"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Greek letter following 72A",
@@ -3031,7 +3563,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Greek letter following 72A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Misplace",
@@ -3058,7 +3597,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Misplace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Wee boy",
@@ -3081,7 +3627,14 @@
             "type": "letter",
             "letter": "D"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Wee boy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Dad to Tommy Pickles",
@@ -3104,7 +3657,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Dad to Tommy Pickles"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The only Patrol I trust",
@@ -3127,7 +3687,14 @@
             "type": "letter",
             "letter": "W"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The only Patrol I trust"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Smart savings plan, briefly",
@@ -3150,7 +3717,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Smart savings plan, briefly"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Fresh",
@@ -3173,7 +3747,14 @@
             "type": "letter",
             "letter": "W"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Fresh"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Breeds such as Chihuahua or Pomeranian",
@@ -3196,7 +3777,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Breeds such as Chihuahua or Pomeranian"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Bega behind \"Mambo No. 5\"",
@@ -3219,7 +3807,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Bega behind \"Mambo No. 5\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Aardvark breakfast",
@@ -3242,7 +3837,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Aardvark breakfast"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sonic ___",
@@ -3265,7 +3867,14 @@
             "type": "letter",
             "letter": "Z"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Sonic ___"
+          ]
+        ],
+        "direction": "down"
       }
     ]
   },

--- a/tests/output/fail_bad_meta.xd.json
+++ b/tests/output/fail_bad_meta.xd.json
@@ -921,7 +921,14 @@
             "type": "letter",
             "letter": "B"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Captain of the Pequod"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Food for second chance chewing",
@@ -944,7 +951,14 @@
             "type": "letter",
             "letter": "D"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Food for second chance chewing"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Font feature",
@@ -975,7 +989,14 @@
             "type": "letter",
             "letter": "F"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Font feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Palindromic address to a female",
@@ -1006,7 +1027,14 @@
             "type": "letter",
             "letter": "M"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Palindromic address to a female"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___ Way You Want It",
@@ -1029,7 +1057,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___ Way You Want It"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Place often described as humble",
@@ -1060,7 +1095,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Place often described as humble"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Flat two dimensional surface in geometry",
@@ -1091,7 +1133,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Flat two dimensional surface in geometry"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Grim homophone of 7D",
@@ -1114,7 +1163,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Grim homophone of 7D"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Off",
@@ -1145,7 +1201,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Off"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Heading for some lists",
@@ -1172,7 +1235,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Heading for some lists"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Kanye West is famous for his",
@@ -1195,7 +1265,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Kanye West is famous for his"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Laceration",
@@ -1222,7 +1299,14 @@
             "type": "letter",
             "letter": "H"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Laceration"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Alias of Twitch star Richard Tyler Blevins",
@@ -1253,7 +1337,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Alias of Twitch star Richard Tyler Blevins"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Capsize",
@@ -1280,7 +1371,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Capsize"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Piece of clothing or print",
@@ -1319,7 +1417,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Piece of clothing or print"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Evangelical school in Tulsa, OK",
@@ -1342,7 +1447,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Evangelical school in Tulsa, OK"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "___-eyed",
@@ -1365,7 +1477,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___-eyed"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Annual",
@@ -1400,7 +1519,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Annual"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The stamp with the upside down airplane is a famous one",
@@ -1443,7 +1569,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The stamp with the upside down airplane is a famous one"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "With 42A and Marcus, a luxury department store chain",
@@ -1466,7 +1599,14 @@
             "type": "letter",
             "letter": "I"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "With 42A and Marcus, a luxury department store chain"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "41A continued",
@@ -1489,7 +1629,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "41A continued"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lush",
@@ -1512,7 +1659,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lush"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "The Mayan one ended in 2012",
@@ -1555,7 +1709,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The Mayan one ended in 2012"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What a child often does to their shoes",
@@ -1590,7 +1751,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What a child often does to their shoes"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Vanilla ___",
@@ -1613,7 +1781,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Vanilla ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Maligned cigarette ingredient",
@@ -1636,7 +1811,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Maligned cigarette ingredient"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Frequent cause for a new tire",
@@ -1675,7 +1857,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Frequent cause for a new tire"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Los Angeles heavy metal act",
@@ -1702,7 +1891,14 @@
             "type": "letter",
             "letter": "P"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Los Angeles heavy metal act"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Bldgs. such as the Googleplex",
@@ -1733,7 +1929,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Bldgs. such as the Googleplex"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "A fit of irritation",
@@ -1760,7 +1963,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "A fit of irritation"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lead-in to American or day",
@@ -1783,7 +1993,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lead-in to American or day"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "What Pokémon do at a Pokémon Center",
@@ -1810,7 +2027,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What Pokémon do at a Pokémon Center"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nixon's vice",
@@ -1841,7 +2065,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Nixon's vice"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Nothing but ___",
@@ -1864,7 +2095,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Nothing but ___"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "One with the world on his shoulders",
@@ -1895,7 +2133,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "One with the world on his shoulders"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Filled pastries",
@@ -1926,7 +2171,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Filled pastries"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Age, in Milan",
@@ -1949,7 +2201,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Age, in Milan"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Lorna ___, novel or cookie",
@@ -1980,7 +2239,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Lorna ___, novel or cookie"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Electrocardiogram readout feature",
@@ -2011,7 +2277,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Electrocardiogram readout feature"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Hip slang for records",
@@ -2034,7 +2307,14 @@
             "type": "letter",
             "letter": "X"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Hip slang for records"
+          ]
+        ],
+        "direction": "across"
       },
       {
         "body": "Yiddish for a foolish person",
@@ -2061,7 +2341,14 @@
             "type": "letter",
             "letter": "Z"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Yiddish for a foolish person"
+          ]
+        ],
+        "direction": "across"
       }
     ],
     "down": [
@@ -2086,7 +2373,14 @@
             "type": "letter",
             "letter": "P"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Pc. of concert gear"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "AI antagonist of 2001",
@@ -2109,7 +2403,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "AI antagonist of 2001"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Programming pioneer Lovelace",
@@ -2132,7 +2433,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Programming pioneer Lovelace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Prohibit",
@@ -2155,7 +2463,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Prohibit"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of person to routinely carry a club",
@@ -2190,7 +2505,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of person to routinely carry a club"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "State of the ___ Address",
@@ -2221,7 +2543,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "State of the ___ Address"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Colorful homophone of 18A",
@@ -2244,7 +2573,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Colorful homophone of 18A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Snitched",
@@ -2271,7 +2607,14 @@
             "type": "letter",
             "letter": "G"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Snitched"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Kindle fare",
@@ -2302,7 +2645,14 @@
             "type": "letter",
             "letter": "K"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Kindle fare"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Decayed matter",
@@ -2325,7 +2675,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Decayed matter"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of response you hope to get at the altar",
@@ -2348,7 +2705,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of response you hope to get at the altar"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Peat-accumulating wetland",
@@ -2371,7 +2735,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Peat-accumulating wetland"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The ___, NY art museum",
@@ -2394,7 +2765,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The ___, NY art museum"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "___Fans",
@@ -2421,7 +2799,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "___Fans"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Friends, Romans, countrymen, lend me your...",
@@ -2448,7 +2833,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Friends, Romans, countrymen, lend me your..."
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "\"Friend of Dorothy\"",
@@ -2471,7 +2863,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "\"Friend of Dorothy\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "We ___ the Champions",
@@ -2494,7 +2893,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "We ___ the Champions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Father of Spider-Man",
@@ -2533,7 +2939,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Father of Spider-Man"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "What a certain applicant becomes",
@@ -2564,7 +2977,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "What a certain applicant becomes"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Connect",
@@ -2591,7 +3011,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Connect"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Particular form of a published text",
@@ -2630,7 +3057,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Particular form of a published text"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Suffix at the end of all of Eevee's evolutions",
@@ -2653,7 +3087,14 @@
             "type": "letter",
             "letter": "N"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Suffix at the end of all of Eevee's evolutions"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Live and ___ Die",
@@ -2676,7 +3117,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Live and ___ Die"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Famous Eastwood whose name became a famous Gorillaz song",
@@ -2707,7 +3155,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Famous Eastwood whose name became a famous Gorillaz song"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Unexpected result in a sporting competition",
@@ -2738,7 +3193,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Unexpected result in a sporting competition"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Disfigure",
@@ -2761,7 +3223,14 @@
             "type": "letter",
             "letter": "R"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Disfigure"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "David Lee and Tim",
@@ -2792,7 +3261,14 @@
             "type": "letter",
             "letter": "S"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "David Lee and Tim"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Luxury watch collection by Garmin",
@@ -2819,7 +3295,14 @@
             "type": "letter",
             "letter": "Q"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Luxury watch collection by Garmin"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Top dog in an IT org",
@@ -2842,7 +3325,14 @@
             "type": "letter",
             "letter": "O"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Top dog in an IT org"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sister ___",
@@ -2865,7 +3355,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Sister ___"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Author Roald",
@@ -2892,7 +3389,14 @@
             "type": "letter",
             "letter": "L"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Author Roald"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Civil rights activist Parks",
@@ -2919,7 +3423,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Civil rights activist Parks"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "An additional name that could be part of 40D's clue",
@@ -2942,7 +3453,14 @@
             "type": "letter",
             "letter": "I"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "An additional name that could be part of 40D's clue"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Director's domain",
@@ -2965,7 +3483,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Director's domain"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Type of income to go in a 401k",
@@ -3000,7 +3525,14 @@
             "type": "letter",
             "letter": "X"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Type of income to go in a 401k"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The Empire Strikes Back, to the Star Wars saga",
@@ -3031,7 +3563,14 @@
             "type": "letter",
             "letter": "V"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The Empire Strikes Back, to the Star Wars saga"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Greek letter following 72A",
@@ -3062,7 +3601,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Greek letter following 72A"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Misplace",
@@ -3089,7 +3635,14 @@
             "type": "letter",
             "letter": "E"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Misplace"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Wee boy",
@@ -3112,7 +3665,14 @@
             "type": "letter",
             "letter": "D"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Wee boy"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Dad to Tommy Pickles",
@@ -3135,7 +3695,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Dad to Tommy Pickles"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "The only Patrol I trust",
@@ -3158,7 +3725,14 @@
             "type": "letter",
             "letter": "W"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "The only Patrol I trust"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Smart savings plan, briefly",
@@ -3181,7 +3755,14 @@
             "type": "letter",
             "letter": "A"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Smart savings plan, briefly"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Fresh",
@@ -3204,7 +3785,14 @@
             "type": "letter",
             "letter": "W"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Fresh"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Breeds such as Chihuahua or Pomeranian",
@@ -3227,7 +3815,14 @@
             "type": "letter",
             "letter": "Y"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Breeds such as Chihuahua or Pomeranian"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Bega behind \"Mambo No. 5\"",
@@ -3250,7 +3845,14 @@
             "type": "letter",
             "letter": "U"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Bega behind \"Mambo No. 5\""
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Aardvark breakfast",
@@ -3273,7 +3875,14 @@
             "type": "letter",
             "letter": "T"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Aardvark breakfast"
+          ]
+        ],
+        "direction": "down"
       },
       {
         "body": "Sonic ___",
@@ -3296,7 +3905,14 @@
             "type": "letter",
             "letter": "Z"
           }
-        ]
+        ],
+        "display": [
+          [
+            "text",
+            "Sonic ___"
+          ]
+        ],
+        "direction": "down"
       }
     ]
   },

--- a/tests/xdparser2/xdparser.mdclue.test.ts
+++ b/tests/xdparser2/xdparser.mdclue.test.ts
@@ -1,25 +1,55 @@
-import { inlineBBCodeParser, xdParser } from "../../lib/xdparser2"
+import { xdMarkupProcessor, xdParser } from "../../lib/xdparser2"
 import { readFileSync } from "fs"
 
 it("handles bolding", () => {
   const xd = readFileSync("tests/xdparser2/inputs/alpha-bits.xd", "utf8")
   const originalClue = "A1. Captain of the Pequod ~ AHAB"
-  const newMDClue = "A1. [b]Captain[/b] of the Pequod ~ AHAB"
+  const newMDClue = "A1. {/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@} ~ AHAB"
 
   const json = xdParser(xd.replace(originalClue, newMDClue))
   const clue = json.clues.across[0]
   expect(clue).toMatchInlineSnapshot(`
 {
   "answer": "AHAB",
-  "body": "[b]Captain[/b] of the Pequod",
-  "bodyMD": [
+  "body": "{/Captain/}, {*of*}, {_the_}, ship {-pequod-} {@see here|https://mylink.com@}",
+  "direction": "across",
+  "display": [
     [
-      "bold",
+      "italics",
       "Captain",
     ],
     [
       "text",
-      " of the Pequod",
+      ", ",
+    ],
+    [
+      "bold",
+      "of",
+    ],
+    [
+      "text",
+      ", ",
+    ],
+    [
+      "underscore",
+      "the",
+    ],
+    [
+      "text",
+      ", ship ",
+    ],
+    [
+      "strike",
+      "pequod",
+    ],
+    [
+      "text",
+      " ",
+    ],
+    [
+      "link",
+      "see here",
+      "https://mylink.com",
     ],
   ],
   "metadata": undefined,
@@ -50,160 +80,81 @@ it("handles bolding", () => {
 `)
 })
 
-it("correctly handles non BBCode syntax", () => {
-  const newMDClue = "A1. The date of 2024/11/12. [MUAH]HEHE XD KISSES MEOW HEHE XD[/MUAH] [][/] [URMOM]()[/]"
-  const parsed = inlineBBCodeParser(newMDClue)
+it("correctly handles xd-spec syntax", () => {
+  const newMDClue = "{/Italic/}, {_bold_}, {_underscore_}, or {-strike-thru-}"
+  const parsed = xdMarkupProcessor(newMDClue)
   expect(parsed).toMatchInlineSnapshot(`
 [
-  [
-    "text",
-    "A1. The date of 2024/11/12. [MUAH]HEHE XD KISSES MEOW HEHE XD[/MUAH] [][/] [URMOM]()[/]",
-  ],
-]
-`)
-
-})
-
-it("parses BBCode italics", () => {
-  const newMDClue = "A1. [i]HI[/i]"
-  const parsed = inlineBBCodeParser(newMDClue)
-  expect(parsed).toMatchInlineSnapshot(`
-[
-  [
-    "text",
-    "A1. ",
-  ],
   [
     "italics",
-    "HI",
+    "Italic",
   ],
-]
-`)
-})
-
-it("parses BBCode strikes", () => {
-  const newMDClue = "A1. [s]NO[/s]"
-  const parsed = inlineBBCodeParser(newMDClue)
-  expect(parsed).toMatchInlineSnapshot(`
-[
   [
     "text",
-    "A1. ",
+    ", ",
+  ],
+  [
+    "underscore",
+    "bold",
+  ],
+  [
+    "text",
+    ", ",
+  ],
+  [
+    "underscore",
+    "underscore",
+  ],
+  [
+    "text",
+    ", or ",
   ],
   [
     "strike",
-    "NO",
+    "strike-thru",
   ],
 ]
 `)
 })
 
-it("parses BBCode bolds", () => {
-  const newMDClue = "A1. [b]NO[/b]"
-  const parsed = inlineBBCodeParser(newMDClue)
+it("correctly handles a URL", () => {
+  const newMDClue = "I think {@you should read|https://github.com@} more"
+  const parsed = xdMarkupProcessor(newMDClue)
   expect(parsed).toMatchInlineSnapshot(`
 [
   [
     "text",
-    "A1. ",
-  ],
-  [
-    "bold",
-    "NO",
-  ],
-]
-`)
-})
-
-it("parses BBCode urls", () => {
-  const newMDClue = "A1. [url=https://lmao.com/chicken]lmao[/url]"
-  const parsed = inlineBBCodeParser(newMDClue)
-  expect(parsed).toMatchInlineSnapshot(`
-[
-  [
-    "text",
-    "A1. ",
+    "I think ",
   ],
   [
     "link",
-    "https://lmao.com/chicken",
-    "lmao",
+    "you should read",
+    "https://github.com",
+  ],
+  [
+    "text",
+    " more",
   ],
 ]
 `)
 })
 
-it("handles links, bolds, italics, strikes, and dates", () => {
-  const newMDClue = "A1. The date of 2024/11/12. [index]arr is good in C WHAT? (SIKE BOIIIIIIIIIIIII MAYBE MAYBE) [i]MEOW[/i][b]MOO[/b][b]HAHA[/b][s]WOOHOO[/s]https://github.com/cod1r.[url=https://google.com]google[/url] [url=https://puzzmo.com/bongo/submit?date=JASONHO]jason's puzzmo[/url][b]INBETWEEN[/b][url=https://google.com]hheh[/url] [s]HEHE[/s] [i]MEOWMEOW[/i] CHICKEN NOODLE SOUP"
-  const parsed = inlineBBCodeParser(newMDClue)
+it("correctly handles ~ for strike also", () => {
+  const newMDClue = "I {~think~}, no.. I know"
+  const parsed = xdMarkupProcessor(newMDClue)
   expect(parsed).toMatchInlineSnapshot(`
 [
   [
     "text",
-    "A1. The date of 2024/11/12. [index]arr is good in C WHAT? (SIKE BOIIIIIIIIIIIII MAYBE MAYBE) ",
-  ],
-  [
-    "italics",
-    "MEOW",
-  ],
-  [
-    "bold",
-    "MOO",
-  ],
-  [
-    "bold",
-    "HAHA",
+    "I ",
   ],
   [
     "strike",
-    "WOOHOO",
+    "think",
   ],
   [
     "text",
-    "https://github.com/cod1r.",
-  ],
-  [
-    "link",
-    "https://google.com",
-    "google",
-  ],
-  [
-    "text",
-    " ",
-  ],
-  [
-    "link",
-    "https://puzzmo.com/bongo/submit?date=JASONHO",
-    "jason's puzzmo",
-  ],
-  [
-    "bold",
-    "INBETWEEN",
-  ],
-  [
-    "link",
-    "https://google.com",
-    "hheh",
-  ],
-  [
-    "text",
-    " ",
-  ],
-  [
-    "strike",
-    "HEHE",
-  ],
-  [
-    "text",
-    " ",
-  ],
-  [
-    "italics",
-    "MEOWMEOW",
-  ],
-  [
-    "text",
-    " CHICKEN NOODLE SOUP",
+    ", no.. I know",
   ],
 ]
 `)

--- a/tests/xdparser2/xdparser.test.ts
+++ b/tests/xdparser2/xdparser.test.ts
@@ -207,6 +207,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "BULB",
       "body": "Gardener's concern.",
+      "direction": "across",
+      "display": [
+        [
+          "text",
+          "Gardener's concern.",
+        ],
+      ],
       "metadata": undefined,
       "number": 1,
       "position": {
@@ -235,6 +242,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "OK",
       "body": "A reasonable statement.",
+      "direction": "across",
+      "display": [
+        [
+          "text",
+          "A reasonable statement.",
+        ],
+      ],
       "metadata": undefined,
       "number": 4,
       "position": {
@@ -255,6 +269,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "DESK",
       "body": "The office centerpiece.",
+      "direction": "across",
+      "display": [
+        [
+          "text",
+          "The office centerpiece.",
+        ],
+      ],
       "metadata": undefined,
       "number": 5,
       "position": {
@@ -285,6 +306,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "BOLD",
       "body": "To _ly go.",
+      "direction": "down",
+      "display": [
+        [
+          "text",
+          "To _ly go.",
+        ],
+      ],
       "metadata": undefined,
       "number": 1,
       "position": {
@@ -313,6 +341,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "UK",
       "body": "Bigger than britain.",
+      "direction": "down",
+      "display": [
+        [
+          "text",
+          "Bigger than britain.",
+        ],
+      ],
       "metadata": undefined,
       "number": 2,
       "position": {
@@ -333,6 +368,13 @@ D3. A conscious tree. ~ BOOK
     {
       "answer": "BOOK",
       "body": "A conscious tree.",
+      "direction": "down",
+      "display": [
+        [
+          "text",
+          "A conscious tree.",
+        ],
+      ],
       "metadata": undefined,
       "number": 3,
       "position": {
@@ -513,6 +555,13 @@ D2. A thing. ~ OBJECT
     {
       "answer": "OK|GO",
       "body": "Band with two words.",
+      "direction": "across",
+      "display": [
+        [
+          "text",
+          "Band with two words.",
+        ],
+      ],
       "metadata": {
         "answer:unprocessed": "OK|GO",
         "body:line": "18",
@@ -546,6 +595,13 @@ D2. A thing. ~ OBJECT
     {
       "answer": "OH|OH|OH",
       "body": "Reverse santa.",
+      "direction": "down",
+      "display": [
+        [
+          "text",
+          "Reverse santa.",
+        ],
+      ],
       "metadata": {
         "answer:unprocessed": "OH|OH|OH",
         "body:line": "20",
@@ -585,6 +641,13 @@ D2. A thing. ~ OBJECT
     {
       "answer": "OBJECT",
       "body": "A thing.",
+      "direction": "down",
+      "display": [
+        [
+          "text",
+          "A thing.",
+        ],
+      ],
       "metadata": {
         "answer:unprocessed": "OBJECT",
         "body:line": "21",


### PR DESCRIPTION
Switches us to conform to [the xd spec](https://github.com/century-arcade/xd/blob/master/doc/xd-format.md#clues-section-3) instead of a different markup language entirely

As I was in here, I also added a way to get to whether the clue is an across or down to save passing that information around everywhere (or worse, making a type which does just this, which I have done a few times in studio)