### PR TITLE
Store unknown sections inside the xd parser json

### DIFF
--- a/packages/xd-crossword-tools-parser/src/parser/xdparser.test.ts
+++ b/packages/xd-crossword-tools-parser/src/parser/xdparser.test.ts
@@ -786,3 +786,60 @@ A2. Alphabet ~ A|B|C
   expect(json.clues.across[0].splits).toEqual([0])
   expect(json.clues.across[1].splits).toEqual([0, 1])
 })
+
+describe("unknownSections", () => {
+  it("captures unknown sections and their content", () => {
+    const xd = `## Metadata
+Title: Test Puzzle
+Author: Test Author
+
+## Custom Section
+This is some custom content
+with multiple lines.
+
+## Another Section!
+More content here.
+Even more content.
+
+## Grid
+## Clues
+`
+
+    const json = xdToJSON(xd)
+    expect(json.unknownSections).toMatchInlineSnapshot(`
+{
+  "another-section": {
+    "content": "More content here.
+Even more content.",
+    "title": "Another Section!",
+  },
+  "custom-section": {
+    "content": "This is some custom content
+with multiple lines.",
+    "title": "Custom Section",
+  },
+}
+`)
+  })
+
+  it("handles empty unknown sections", () => {
+    const xd = `## Metadata
+Title: Test Puzzle
+
+## Empty Section
+
+## Grid
+## Clues
+`
+
+    const json = xdToJSON(xd)
+    expect(json.unknownSections).toMatchInlineSnapshot(`
+{
+  "empty-section": {
+    "content": "",
+    "title": "Empty Section",
+  },
+}
+`)
+  })
+})

--- a/packages/xd-crossword-tools-parser/src/types.ts
+++ b/packages/xd-crossword-tools-parser/src/types.ts
@@ -52,6 +52,11 @@ export type CrosswordJSON = {
     /** Lint warnings which are general 'hey should you be doing this?' */
     warnings: Report[]
   }
+  /**
+   * If there are any sections which were not known, we slugify
+   * the title and use it as the key, then add the text content as the value
+   */
+  unknownSections: Record<string, { title: string; content: string }>
 }
 
 export type Report =


### PR DESCRIPTION
For example

```
## Metadata
Title: Test Puzzle
Author: Test Author

## Intro HTML
<div class="">Hello world</div>

## Another Section!
More content here.
Even more content.

## Grid
## Clues
```

would have a key for `intro-html` and `another-section` in `json.unknownSections`