### PR TITLE
Amuse import improvements

### DIFF
--- a/packages/xd-crossword-tools/src/JSONtoXD.ts
+++ b/packages/xd-crossword-tools/src/JSONtoXD.ts
@@ -187,5 +187,11 @@ export const JSONToXD = (json: CrosswordJSON): string => {
     xd += json.notes
   }
 
+  // Add unknown sections
+  for (const [key, section] of Object.entries(json.unknownSections)) {
+    xd += `\n\n## ${section.title}\n\n`
+    xd += section.content
+  }
+
   return xd
 }

--- a/packages/xd-crossword-tools/src/amuseJSONToXD.ts
+++ b/packages/xd-crossword-tools/src/amuseJSONToXD.ts
@@ -5,14 +5,14 @@ import { cleanupClueMetadata } from "./cleanupClueMetadata"
 import type { CellInfo, PlacedWord, AmuseTopLevel } from "./amuseJSONToXD.types.d.ts"
 
 /** Convert an Amuse JSON to an XD file. */
-export const amuseToXD = (amuseJSON: AmuseTopLevel) => JSONToXD(convertTopLevelToCrosswordJSON(amuseJSON))
+export const amuseToXD = (amuseJSON: AmuseTopLevel) => JSONToXD(convertAmuseToCrosswordJSON(amuseJSON))
 
 type Clues = CrosswordJSON["clues"]
 type Meta = CrosswordJSON["meta"]
 type Tiles = CrosswordJSON["tiles"]
 type Tile = Tiles[number][number]
 
-export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): CrosswordJSON {
+export function convertAmuseToCrosswordJSON(amuseJson: AmuseTopLevel): CrosswordJSON {
   const { attributes } = amuseJson.data
   const amuseData = attributes.amuse_data // amuseData is of type AmuseData
 
@@ -32,7 +32,7 @@ export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): Crossw
     id: attributes.amuse_id || amuseData.id,
   }
 
-  // Tiles
+  // Tiles - using row-major order [y][x]
   const tiles: Tile[][] = Array(amuseData.h)
     .fill(null)
     .map(() => Array(amuseData.w).fill(null))
@@ -44,17 +44,33 @@ export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): Crossw
     }
   }
 
+  // Track circled cells and bars for design section
+  const hasCircledCells = amuseData.cellInfos?.some((cell) => cell.isCircled) || false
+  const hasBars = amuseData.cellInfos?.some((cell) => cell.rightWall || cell.bottomWall) || false
+  const needsDesign = hasCircledCells || hasBars
+
+  let designPositions: string[][] | undefined = undefined
+  let designStyles: Record<string, Record<string, string>> = {}
+  let barDesignMap: Map<string, Set<string>> = new Map() // Map of "y-x" to Set of design flags
+
+  if (needsDesign) {
+    designPositions = Array(amuseData.h)
+      .fill(null)
+      .map(() => Array(amuseData.w).fill(null))
+  }
+
+  // First pass: create tiles and track walls
   for (let y = 0; y < amuseData.h; y++) {
     for (let x = 0; x < amuseData.w; x++) {
       const letterFromBox = amuseData.box[y]?.[x] as string | null
       const clueNumString = amuseData.clueNums[y]?.[x]
-      // const cellKey = `${y}-${x}`
-      // const specificCellInfo = cellInfoMap.get(cellKey)
+      const cellKey = `${y}-${x}`
+      const specificCellInfo = cellInfoMap.get(cellKey)
 
       if (letterFromBox === null || letterFromBox === "." || letterFromBox === "#") {
-        tiles[x][y] = { type: "blank" }
+        tiles[y][x] = { type: "blank" }
       } else {
-        tiles[x][y] = {
+        tiles[y][x] = {
           type: "letter",
           letter: letterFromBox || "",
           clues: {
@@ -63,7 +79,96 @@ export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): Crossw
           },
         }
       }
-      // TODO: Rebus tiles
+
+      // Track circled cells in design positions
+      if (designPositions && specificCellInfo?.isCircled) {
+        designPositions[y][x] = "O"
+        designStyles["O"] = { background: "circle" }
+      }
+
+      // Convert walls to bars
+      if (specificCellInfo) {
+        // rightWall on (x,y) means bar-left on (x+1,y)
+        if (specificCellInfo.rightWall && x + 1 < amuseData.w) {
+          const targetKey = `${y}-${x + 1}`
+          if (!barDesignMap.has(targetKey)) {
+            barDesignMap.set(targetKey, new Set())
+          }
+          barDesignMap.get(targetKey)!.add("bar-left")
+        }
+
+        // bottomWall on (x,y) means bar-top on (x,y+1)
+        if (specificCellInfo.bottomWall && y + 1 < amuseData.h) {
+          const targetKey = `${y + 1}-${x}`
+          if (!barDesignMap.has(targetKey)) {
+            barDesignMap.set(targetKey, new Set())
+          }
+          barDesignMap.get(targetKey)!.add("bar-top")
+        }
+      }
+    }
+  }
+
+  // Second pass: apply bar designs to tiles and design positions
+  if (hasBars && designPositions) {
+    // We'll use letters to represent different bar combinations
+    const barStyles: Map<string, string[]> = new Map()
+    let nextBarLetter = 65 // ASCII 'A'
+
+    for (const [cellKey, designFlags] of barDesignMap) {
+      const [yStr, xStr] = cellKey.split("-")
+      const y = parseInt(yStr)
+      const x = parseInt(xStr)
+
+      // Skip if this is a blank tile
+      if (tiles[y][x].type === "blank") continue
+
+      // Create a unique style key for this combination of bars
+      const sortedFlags = Array.from(designFlags).sort()
+      const styleKey = sortedFlags.join("|")
+
+      let styleLetter: string
+      if (!barStyles.has(styleKey)) {
+        styleLetter = String.fromCharCode(nextBarLetter++)
+        barStyles.set(styleKey, sortedFlags)
+
+        // Add to design styles
+        const styleObj: Record<string, string> = {}
+        if (sortedFlags.includes("bar-left")) styleObj["bar-left"] = "true"
+        if (sortedFlags.includes("bar-top")) styleObj["bar-top"] = "true"
+        designStyles[styleLetter] = styleObj
+      } else {
+        // Find the letter for this style combination
+        styleLetter = Array.from(barStyles.entries())
+          .find(([key]) => key === styleKey)![1]
+          .map(() => String.fromCharCode(nextBarLetter - barStyles.size + Array.from(barStyles.keys()).indexOf(styleKey)))[0]
+      }
+
+      // Mark this position in the design grid
+      if (!designPositions[y][x]) {
+        // Find or create the appropriate letter for this bar combination
+        for (const [letter, style] of Object.entries(designStyles)) {
+          const hasBarLeft = style["bar-left"] === "true"
+          const hasBarTop = style["bar-top"] === "true"
+          const wantsBarLeft = sortedFlags.includes("bar-left")
+          const wantsBarTop = sortedFlags.includes("bar-top")
+
+          if (hasBarLeft === wantsBarLeft && hasBarTop === wantsBarTop && letter !== "O") {
+            designPositions[y][x] = letter
+            break
+          }
+        }
+
+        // If we didn't find a matching style, create a new one
+        if (!designPositions[y][x]) {
+          const newLetter = String.fromCharCode(Object.keys(designStyles).filter((k) => k !== "O").length + 65)
+          const styleObj: Record<string, string> = {}
+          if (sortedFlags.includes("bar-left")) styleObj["bar-left"] = "true"
+          if (sortedFlags.includes("bar-top")) styleObj["bar-top"] = "true"
+          designStyles[newLetter] = styleObj
+          designPositions[y][x] = newLetter
+        }
+      }
     }
   }
 
@@ -88,6 +193,14 @@ export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): Crossw
         col: placedWord.x,
         index: placedWord.y,
       },
+      // Add revealer metadata if refText exists
+      ...(placedWord.clue.refText
+        ? {
+            metadata: {
+              revealer: placedWord.clue.refText,
+            },
+          }
+        : {}),
     }
 
     const clueId = `${clueNumberStr}-${direction}`
@@ -119,6 +232,15 @@ export function convertTopLevelToCrosswordJSON(amuseJson: AmuseTopLevel): Crossw
       errors: [],
       warnings: [],
     },
+    // Add design section if there are circled cells or bars
+    ...(designPositions
+      ? {
+          design: {
+            styles: designStyles,
+            positions: designPositions,
+          },
+        }
+      : {}),
   }
 
   cleanupClueMetadata(result)

--- a/packages/xd-crossword-tools/src/amuseJSONToXD.ts
+++ b/packages/xd-crossword-tools/src/amuseJSONToXD.ts
@@ -22,6 +22,7 @@ export function convertAmuseToCrosswordJSON(amuseJson: AmuseTopLevel): Crossword
 
   const meta: Meta = {
     title: amuseData.title || "Untitled Crossword",
+    subtitle: amuseData.subtitle,
     author: amuseData.author || "Unknown Author",
     date: formatDate(amuseData.publishTime),
     // copyright: amuseData.copyright === Copyright.Empty ? "" : amuseData.copyright,
@@ -29,7 +30,10 @@ export function convertAmuseToCrosswordJSON(amuseJson: AmuseTopLevel): Crossword
     width: amuseData.w.toString(),
     height: amuseData.h.toString(),
     editor: "not in data",
-    id: attributes.amuse_id || amuseData.id,
+
+    id: amuseData.id,
+    amuseID: attributes.amuse_id,
+    set: attributes.amuse_set,
   }
 
   // Tiles - using row-major order [y][x]
@@ -220,13 +224,32 @@ export function convertAmuseToCrosswordJSON(amuseJson: AmuseTopLevel): Crossword
     }
   })
 
+  // Prepare unknown sections for HTML content
+  const unknownSections: Record<string, { title: string; content: string }> = {}
+
+  if (amuseData.description && amuseData.description.trim()) {
+    unknownSections["description"] = { title: "Description", content: amuseData.description }
+  }
+
+  if (amuseData.help && amuseData.help.trim()) {
+    unknownSections["help"] = { title: "Help", content: amuseData.help }
+  }
+
+  if (amuseData.pauseMessage && amuseData.pauseMessage.trim()) {
+    unknownSections["pausemessage"] = { title: "Pause Message", content: amuseData.pauseMessage }
+  }
+
+  if (amuseData.endMessage && amuseData.endMessage.trim()) {
+    unknownSections["endmessage"] = { title: "End Message", content: amuseData.endMessage }
+  }
+
   const result: CrosswordJSON = {
     tiles,
     clues: cluesStructure,
     meta: meta,
     notes: "",
     rebuses: {},
-    unknownSections: {},
+    unknownSections: unknownSections,
     report: {
       success: true,
       errors: [],

--- a/packages/xd-crossword-tools/src/amuseJSONToXD.types.d.ts
+++ b/packages/xd-crossword-tools/src/amuseJSONToXD.types.d.ts
@@ -25,7 +25,7 @@ export interface AmuseData {
   h: number
   w: number
   id: string
-  box: Array<Array<Direction | null>>
+  box: Array<Array<Letter | null>>
   help: string
   tags: any[]
   title: string
@@ -84,7 +84,7 @@ export interface AmuseData {
   completionSoundURL?: string
 }
 
-export enum Direction {
+export enum Letter {
   A = "A",
   AI = "A/I",
   B = "B",
@@ -150,7 +150,7 @@ export interface PlacedWord {
   nBoxes: number
   clueNum: string
   wordLens?: number[]
-  direction?: Direction
+  direction?: Letter
   intersects: boolean
   clueSection?: ClueSection
   originalTerm: string

--- a/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
@@ -323,8 +323,8 @@ describeConditional("amuseJSONToXD", () => {
       // Check that revealer metadata is properly set
       for (const clue of cluesWithRevealers) {
         expect(clue.metadata?.revealer).toBeDefined()
-        expect(typeof clue.metadata.revealer).toBe("string")
-        expect(clue.metadata.revealer.length).toBeGreaterThan(0)
+        expect(typeof clue.metadata?.revealer).toBe("string")
+        expect(clue.metadata?.revealer.length).toBeGreaterThan(0)
       }
 
       // Check a specific example (first clue with revealer)

--- a/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
@@ -315,7 +315,7 @@ describeConditional("amuseJSONToXD", () => {
 
       // Find clues that should have revealer metadata
       const allClues = [...result.clues.across, ...result.clues.down]
-      const cluesWithRevealers = allClues.filter(clue => clue.metadata?.revealer)
+      const cluesWithRevealers = allClues.filter((clue) => clue.metadata?.revealer)
 
       // The barred cryptic puzzle should have some clues with refText
       expect(cluesWithRevealers.length).toBeGreaterThan(0)
@@ -338,9 +338,45 @@ describeConditional("amuseJSONToXD", () => {
 
       // Check that XD output contains revealer metadata
       expect(xdOutput).toContain("revealer:")
-      
+
       // Should contain the specific revealer content from refText
       expect(xdOutput).toContain("SCAB + BARD")
+    })
+
+    it("includes HTML content sections in XD output", () => {
+      // Use the barred cryptic JSON file which has HTML content
+      const xdOutput = amuseToXD(amuseJSON)
+
+      // Check for End Message section (has HTML content)
+      expect(xdOutput).toContain("## End Message")
+      expect(xdOutput).toContain("Close this pop-up to see an explanation")
+
+      // Check for Pause Message section (has HTML content)
+      expect(xdOutput).toContain("## Pause Message")
+
+      // Check that HTML content is preserved (not stripped)
+      expect(xdOutput).toContain("<div>")
+      expect(xdOutput).toContain("<img")
+    })
+
+    it("includes themed puzzle HTML sections", () => {
+      // Use the themed JSON file which has different HTML content
+      const xdOutput = amuseToXD(themedAmuseJSON)
+
+      // Check for Help section
+      expect(xdOutput).toContain("## Help")
+      expect(xdOutput).toContain("Innovation & Tech issue")
+
+      // Check for End Message section
+      expect(xdOutput).toContain("## End Message")
+      expect(xdOutput).toContain("Sign up for the Puzzles & Games newsletter")
+
+      // Check for Pause Message section
+      expect(xdOutput).toContain("## Pause Message")
+
+      // Check that HTML content is preserved (not stripped)
+      expect(xdOutput).toContain("<p class=")
+      expect(xdOutput).toContain("<a href=")
     })
 
     it("converts barred grids correctly", () => {
@@ -397,27 +433,29 @@ describeConditional("amuseJSONToXD", () => {
       const xdOutput = amuseToXD(amuseJSON)
 
       // Check that XD output contains design section
-      expect("## Design" + xdOutput.split("## Design")[1]).toMatchInlineSnapshot(`
-            "## Design
+      expect("## Design" + xdOutput.split("## Design")[1].split("##")[0]).toMatchInlineSnapshot(`
+        "## Design
 
-            <style>
-            A { bar-top: true }
-            B { bar-left: true; bar-top: true }
-            C { bar-left: true }
-            </style>
+        <style>
+        A { bar-top: true }
+        B { bar-left: true; bar-top: true }
+        C { bar-left: true }
+        </style>
 
-            ........
-            ..A.B.A.
-            ..A...A.
-            .CBCCCBC
-            ........
-            A......A
-            .CCCCCCC
-            .A...A..
-            .A..CA..
-            .A.A.A..
-            "
-          `)
+        ........
+        ..A.B.A.
+        ..A...A.
+        .CBCCCBC
+        ........
+        A......A
+        .CCCCCCC
+        .A...A..
+        .A..CA..
+        .A.A.A..
+
+
+        "
+      `)
     })
 
     it("generates correct XD output with circled cells", () => {

--- a/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
@@ -354,7 +354,7 @@ describeConditional("amuseJSONToXD", () => {
       // Check for Pause Message section (has HTML content)
       expect(xdOutput).toContain("## Pause Message")
 
-      // Check that HTML content is preserved (not stripped)
+      // Should contain text content (HTML converted to markup)
       expect(xdOutput).toContain("<div>")
       expect(xdOutput).toContain("<img")
     })
@@ -374,9 +374,47 @@ describeConditional("amuseJSONToXD", () => {
       // Check for Pause Message section
       expect(xdOutput).toContain("## Pause Message")
 
-      // Check that HTML content is preserved (not stripped)
       expect(xdOutput).toContain("<p class=")
       expect(xdOutput).toContain("<a href=")
+    })
+
+    it("converts HTML to XD markup format", () => {
+      // Test that HTML in clue text is converted to XD markup
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+      const allClues = [...result.clues.across, ...result.clues.down]
+
+      // Find clues that have revealer metadata
+      const cluesWithRevealers = allClues.filter((clue) => clue.metadata?.revealer)
+      expect(cluesWithRevealers.length).toBeGreaterThan(0)
+
+      // Check for XD markup in revealer metadata - it should contain {/italic/} from <i> tags
+      let hasItalicMarkup = false
+      for (const clue of cluesWithRevealers) {
+        if (clue.metadata?.revealer?.includes("{/") && clue.metadata.revealer.includes("/}")) {
+          hasItalicMarkup = true
+          break
+        }
+      }
+
+      // Test completed successfully - HTML conversion is working
+
+      expect(hasItalicMarkup).toBe(true)
+
+      // Check that HTML tags are converted, not preserved
+      for (const clue of allClues) {
+        if (clue.metadata?.revealer) {
+          expect(clue.metadata.revealer).not.toContain("<i>")
+          expect(clue.metadata.revealer).not.toContain("<b>")
+          expect(clue.metadata.revealer).not.toContain("<em>")
+          expect(clue.metadata.revealer).not.toContain("<strong>")
+        }
+
+        // Also check clue bodies don't have HTML tags
+        expect(clue.body).not.toContain("<i>")
+        expect(clue.body).not.toContain("<b>")
+        expect(clue.body).not.toContain("<em>")
+        expect(clue.body).not.toContain("<strong>")
+      }
     })
 
     it("converts barred grids correctly", () => {

--- a/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
@@ -1,0 +1,448 @@
+import { existsSync, readFileSync } from "fs"
+import { amuseToXD, convertAmuseToCrosswordJSON } from "../src/amuseJSONToXD"
+import type { AmuseTopLevel } from "../src/amuseJSONToXD.types"
+import { beforeAll, describe, expect, it } from "vitest"
+
+const exampleJSONPath = "/Users/orta/dev/workshop/packages/amuse-to-xd/examples/2024_03_17-barred_cryptic.json"
+const fullExamplePath = exampleJSONPath
+
+const hasCirclesPath = "/Users/orta/dev/workshop/packages/amuse-to-xd/examples/2025_04_01-themed.json"
+
+// Only run tests if the example JSON files exist
+const shouldRunTests = existsSync(fullExamplePath) && existsSync(hasCirclesPath)
+
+const describeConditional = shouldRunTests ? describe : describe.skip
+
+describeConditional("amuseJSONToXD", () => {
+  let amuseJSON: AmuseTopLevel
+  let themedAmuseJSON: AmuseTopLevel
+
+  beforeAll(() => {
+    const jsonContent = readFileSync(fullExamplePath, "utf-8")
+    amuseJSON = JSON.parse(jsonContent)
+
+    const themedJsonContent = readFileSync(hasCirclesPath, "utf-8")
+    themedAmuseJSON = JSON.parse(themedJsonContent)
+  })
+
+  describe("convertTopLevelToCrosswordJSON", () => {
+    it("converts amuse JSON to CrosswordJSON format", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      expect(result).toHaveProperty("meta")
+      expect(result).toHaveProperty("tiles")
+      expect(result).toHaveProperty("clues")
+      expect(result).toHaveProperty("rebuses")
+      expect(result).toHaveProperty("report")
+      expect(result.report.success).toBe(true)
+    })
+
+    it("properly extracts metadata", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      expect(result.meta).toHaveProperty("title")
+      expect(result.meta).toHaveProperty("author")
+      expect(result.meta).toHaveProperty("date")
+      expect(result.meta).toHaveProperty("width")
+      expect(result.meta).toHaveProperty("height")
+      expect(result.meta).toHaveProperty("id")
+
+      expect(typeof result.meta.title).toBe("string")
+      expect(typeof result.meta.author).toBe("string")
+      expect(typeof result.meta.width).toBe("string")
+      expect(typeof result.meta.height).toBe("string")
+    })
+
+    it("creates proper grid dimensions", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+      const expectedWidth = parseInt(result.meta.width!)
+      const expectedHeight = parseInt(result.meta.height!)
+
+      expect(result.tiles).toHaveLength(expectedHeight)
+      expect(result.tiles[0]).toHaveLength(expectedWidth)
+    })
+
+    it("converts tiles correctly", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      // Check that tiles have proper structure
+      for (const row of result.tiles) {
+        for (const tile of row) {
+          expect(tile).toHaveProperty("type")
+          expect(["letter", "blank", "rebus", "schrodinger"]).toContain(tile.type)
+
+          if (tile.type === "letter") {
+            expect(tile).toHaveProperty("letter")
+            expect(typeof tile.letter).toBe("string")
+          }
+        }
+      }
+    })
+
+    it("converts clues with proper structure", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      expect(result.clues).toHaveProperty("across")
+      expect(result.clues).toHaveProperty("down")
+      expect(Array.isArray(result.clues.across)).toBe(true)
+      expect(Array.isArray(result.clues.down)).toBe(true)
+
+      const allClues = [...result.clues.across, ...result.clues.down]
+
+      for (const clue of allClues) {
+        expect(clue).toHaveProperty("number")
+        expect(clue).toHaveProperty("body")
+        expect(clue).toHaveProperty("answer")
+        expect(clue).toHaveProperty("direction")
+        expect(clue).toHaveProperty("position")
+        expect(clue).toHaveProperty("tiles")
+        expect(clue).toHaveProperty("display")
+
+        expect(typeof clue.number).toBe("number")
+        expect(typeof clue.body).toBe("string")
+        expect(typeof clue.answer).toBe("string")
+        expect(["across", "down"]).toContain(clue.direction)
+        expect(Array.isArray(clue.display)).toBe(true)
+        expect(Array.isArray(clue.tiles)).toBe(true)
+      }
+    })
+
+    it("strips HTML from clue text", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+      const allClues = [...result.clues.across, ...result.clues.down]
+
+      for (const clue of allClues) {
+        // Check that no HTML tags remain in clue body
+        expect(clue.body).not.toMatch(/<[^>]*>/g)
+      }
+    })
+
+    it("formats dates correctly", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      if (result.meta.date) {
+        // Check YYYY-MM-DD format
+        expect(result.meta.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      }
+    })
+
+    it("handles different puzzle types with warning", () => {
+      // Create a mock Amuse JSON with non-crossword type
+      const mockAmuseJSON: AmuseTopLevel = {
+        ...amuseJSON,
+        data: {
+          ...amuseJSON.data,
+          attributes: {
+            ...amuseJSON.data.attributes,
+            amuse_data: {
+              ...amuseJSON.data.attributes.amuse_data,
+              puzzleType: "WORD_SEARCH" as any,
+            },
+          },
+        },
+      }
+
+      const consoleSpy = { warn: console.warn }
+      console.warn = () => {}
+
+      const result = convertAmuseToCrosswordJSON(mockAmuseJSON)
+      expect(result).toHaveProperty("meta")
+
+      console.warn = consoleSpy.warn
+    })
+  })
+
+  describe("amuseToXD", () => {
+    it("converts amuse JSON to XD string format", () => {
+      const result = amuseToXD(amuseJSON)
+
+      expect(typeof result).toBe("string")
+      expect(result).toContain("title:")
+      expect(result).toContain("author:")
+      expect(result).toContain("## Grid")
+      expect(result).toContain("## Clues")
+      expect(result).toContain("## Metadata")
+    })
+
+    it("produces valid XD format with required sections", () => {
+      const result = amuseToXD(amuseJSON)
+      const lines = result.split("\n")
+
+      // Check for required XD sections
+      const hasGrid = lines.some((line) => line.trim() === "## Grid")
+      const hasClues = lines.some((line) => line.trim() === "## Clues")
+      const hasMetadata = lines.some((line) => line.trim() === "## Metadata")
+
+      expect(hasGrid).toBe(true)
+      expect(hasClues).toBe(true)
+      expect(hasMetadata).toBe(true)
+    })
+
+    it("includes clues in proper XD format", () => {
+      const result = amuseToXD(amuseJSON)
+
+      // Should contain clue format: A1. Clue text ~ ANSWER
+      expect(result).toMatch(/A\d+\.\s.+\s~\s[A-Z]+/m)
+      // Should contain down clues: D1. Clue text ~ ANSWER
+      expect(result).toMatch(/D\d+\.\s.+\s~\s[A-Z]+/m)
+    })
+
+    it("includes design section with bars from real data", () => {
+      const result = amuseToXD(amuseJSON)
+
+      // Check that design section exists
+      expect(result).toContain("## Design")
+      expect(result).toContain("<style>")
+      expect(result).toContain("</style>")
+
+      // Check for bar styles
+      expect(result).toMatch(/bar-left.*true/m)
+      expect(result).toMatch(/bar-top.*true/m)
+
+      // The design grid should have letter markers for barred cells
+      const designSection = result.split("## Design")[1]
+      expect(designSection).toBeDefined()
+
+      // Should have style definitions
+      expect(designSection).toContain("{ bar-")
+    })
+  })
+
+  describe("edge cases and error handling", () => {
+    it("handles missing optional fields gracefully", () => {
+      // Create a modified version of the real JSON with some optional fields removed
+      const minimalAmuseJSON: AmuseTopLevel = {
+        ...amuseJSON,
+        data: {
+          ...amuseJSON.data,
+          attributes: {
+            ...amuseJSON.data.attributes,
+            amuse_data: {
+              ...amuseJSON.data.attributes.amuse_data,
+              // Remove optional fields
+              cellInfos: undefined, // Remove cell info (bars and circles)
+              subtitle: "",
+              authorURL: "",
+              authorEmail: "",
+              description: "",
+              attributions: "",
+              pauseMessage: "",
+              endMessage: "",
+              help: "",
+            },
+          },
+        },
+      }
+
+      expect(() => convertAmuseToCrosswordJSON(minimalAmuseJSON)).not.toThrow()
+      const result = convertAmuseToCrosswordJSON(minimalAmuseJSON)
+
+      // Should still have basic metadata
+      expect(result.meta.title).toBeTruthy()
+      expect(result.meta.author).toBeTruthy()
+
+      // Should not have design section since cellInfos is removed
+      expect(result.design).toBeUndefined()
+
+      // Date should still exist from the original data
+      expect(result.meta.date).toBeTruthy()
+
+      // Should still convert successfully
+      expect(result.report.success).toBe(true)
+      expect(result.tiles.length).toBeGreaterThan(0)
+      expect(result.clues.across.length).toBeGreaterThan(0)
+    })
+
+    it("handles empty clue text", () => {
+      const amuseWithEmptyClue = {
+        ...amuseJSON,
+        data: {
+          ...amuseJSON.data,
+          attributes: {
+            ...amuseJSON.data.attributes,
+            amuse_data: {
+              ...amuseJSON.data.attributes.amuse_data,
+              placedWords: [
+                {
+                  ...amuseJSON.data.attributes.amuse_data.placedWords[0],
+                  clue: {
+                    clue: "",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const result = convertAmuseToCrosswordJSON(amuseWithEmptyClue)
+      expect(result.clues.across[0]?.body).toBe("")
+    })
+
+    it("converts circled cells to design section", () => {
+      // Use the real themed JSON file that has circled cells
+      const result = convertAmuseToCrosswordJSON(themedAmuseJSON)
+
+      // Check that design section exists
+      expect(result.design).toBeDefined()
+      expect(result.design?.styles).toBeDefined()
+
+      // Should have circle style
+      expect(result.design?.styles["O"]).toEqual({ background: "circle" })
+
+      // Check that we have circled positions marked with "O"
+      const positions = result.design?.positions || []
+      expect(positions.length).toBe(15) // Height is 15 in the themed data
+      expect(positions[0].length).toBe(15) // Width is 15 in the themed data
+
+      // Find cells with circles (positions marked as "O")
+      let circledCellCount = 0
+      for (const row of positions) {
+        for (const cell of row) {
+          if (cell === "O") {
+            circledCellCount++
+          }
+        }
+      }
+
+      // The themed puzzle should have multiple circled cells
+      expect(circledCellCount).toBeGreaterThan(0)
+    })
+
+    it("converts refText to revealer metadata", () => {
+      // Use the barred cryptic JSON file which has refText entries
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      // Find clues that should have revealer metadata
+      const allClues = [...result.clues.across, ...result.clues.down]
+      const cluesWithRevealers = allClues.filter(clue => clue.metadata?.revealer)
+
+      // The barred cryptic puzzle should have some clues with refText
+      expect(cluesWithRevealers.length).toBeGreaterThan(0)
+
+      // Check that revealer metadata is properly set
+      for (const clue of cluesWithRevealers) {
+        expect(clue.metadata?.revealer).toBeDefined()
+        expect(typeof clue.metadata.revealer).toBe("string")
+        expect(clue.metadata.revealer.length).toBeGreaterThan(0)
+      }
+
+      // Check a specific example (first clue with revealer)
+      const firstClueWithRevealer = cluesWithRevealers[0]
+      expect(firstClueWithRevealer.metadata?.revealer).toContain("SCAB")
+    })
+
+    it("includes revealer metadata in XD output", () => {
+      // Use the barred cryptic JSON file which has refText entries
+      const xdOutput = amuseToXD(amuseJSON)
+
+      // Check that XD output contains revealer metadata
+      expect(xdOutput).toContain("revealer:")
+      
+      // Should contain the specific revealer content from refText
+      expect(xdOutput).toContain("SCAB + BARD")
+    })
+
+    it("converts barred grids correctly", () => {
+      // The real JSON file has bars, so we can use it directly
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      // Check that design section exists (since the real data has bars)
+      expect(result.design).toBeDefined()
+
+      // Check that we have bar styles
+      const styles = result.design?.styles || {}
+      const hasBarLeft = Object.values(styles).some((style) => style["bar-left"] === "true")
+      const hasBarTop = Object.values(styles).some((style) => style["bar-top"] === "true")
+
+      expect(hasBarLeft).toBe(true)
+      expect(hasBarTop).toBe(true)
+
+      // The real data should have multiple bar combinations
+      const styleCount = Object.keys(styles).length
+      expect(styleCount).toBeGreaterThan(1) // Should have at least 2 different styles
+
+      // Check that positions are filled with style letters
+      const positions = result.design?.positions || []
+      expect(positions.length).toBe(10) // Height is 10 in the real data
+      expect(positions[0].length).toBe(8) // Width is 8 in the real data
+
+      // Find cells with bars (non-null, non-undefined positions)
+      let cellsWithBars = 0
+      for (const row of positions) {
+        for (const cell of row) {
+          if (cell && styles[cell]) {
+            cellsWithBars++
+          }
+        }
+      }
+
+      // The real barred grid should have many cells with bars
+      expect(cellsWithBars).toBeGreaterThan(10)
+
+      // Verify that all used letters in positions have corresponding styles
+      const usedLetters = new Set<string>()
+      for (const row of positions) {
+        for (const cell of row) {
+          if (cell) usedLetters.add(cell)
+        }
+      }
+
+      for (const letter of usedLetters) {
+        expect(styles[letter]).toBeDefined()
+      }
+    })
+
+    it("generates a valid xd file from barred cells", () => {
+      const xdOutput = amuseToXD(amuseJSON)
+
+      // Check that XD output contains design section
+      expect("## Design" + xdOutput.split("## Design")[1]).toMatchInlineSnapshot(`
+            "## Design
+
+            <style>
+            A { bar-top: true }
+            B { bar-left: true; bar-top: true }
+            C { bar-left: true }
+            </style>
+
+            ........
+            ..A.B.A.
+            ..A...A.
+            .CBCCCBC
+            ........
+            A......A
+            .CCCCCCC
+            .A...A..
+            .A..CA..
+            .A.A.A..
+            "
+          `)
+    })
+
+    it("generates correct XD output with circled cells", () => {
+      // Use the real themed JSON file
+      const xdOutput = amuseToXD(themedAmuseJSON)
+
+      // Check that XD output contains design section
+      expect(xdOutput).toContain("## Design")
+      expect(xdOutput).toContain("<style>")
+      expect(xdOutput).toContain("O { background: circle }")
+      expect(xdOutput).toContain("</style>")
+
+      // The design grid should have O characters for circled cells
+      const designSection = xdOutput.split("## Design")[1]
+      expect(designSection).toBeDefined()
+      expect(designSection).toContain("O")
+    })
+  })
+})
+
+// If the test files don't exist, provide a helpful message
+if (!shouldRunTests) {
+  describe("amuseJSONToXD (skipped)", () => {
+    it(`skips tests because required files don't exist at: ${exampleJSONPath} or ${hasCirclesPath}`, () => {
+      expect(true).toBe(true) // Placeholder test to avoid empty describe block
+    })
+  })
+}

--- a/packages/xd-crossword-tools/tests/packages/xd-crossword-tools/tests/output/fail_bad_clue.xd.json
+++ b/packages/xd-crossword-tools/tests/packages/xd-crossword-tools/tests/output/fail_bad_clue.xd.json
@@ -922,6 +922,7 @@
             "letter": "B"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -952,6 +953,7 @@
             "letter": "D"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -990,6 +992,7 @@
             "letter": "F"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1020,6 +1023,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1058,6 +1062,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1096,6 +1101,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1126,6 +1132,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1164,6 +1171,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1198,6 +1206,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1228,6 +1237,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1262,6 +1272,7 @@
             "letter": "H"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1300,6 +1311,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1334,6 +1346,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1380,6 +1393,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1410,6 +1424,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1440,6 +1455,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1482,6 +1498,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1532,6 +1549,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1562,6 +1580,7 @@
             "letter": "I"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1592,6 +1611,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1622,6 +1642,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1672,6 +1693,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1714,6 +1736,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1744,6 +1767,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1774,6 +1798,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1820,6 +1845,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1854,6 +1880,7 @@
             "letter": "P"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1892,6 +1919,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1926,6 +1954,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1956,6 +1985,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1990,6 +2020,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2028,6 +2059,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2058,6 +2090,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2096,6 +2129,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2134,6 +2168,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2164,6 +2199,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2202,6 +2238,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2240,6 +2277,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2270,6 +2308,7 @@
             "letter": "X"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2304,6 +2343,7 @@
             "letter": "Z"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2336,6 +2376,7 @@
             "letter": "P"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2366,6 +2407,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2396,6 +2438,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2426,6 +2469,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2468,6 +2512,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2506,6 +2551,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2536,6 +2582,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2570,6 +2617,7 @@
             "letter": "G"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2608,6 +2656,7 @@
             "letter": "K"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2638,6 +2687,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2668,6 +2718,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2698,6 +2749,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2728,6 +2780,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2762,6 +2815,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2796,6 +2850,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2826,6 +2881,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2856,6 +2912,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2902,6 +2959,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2940,6 +2998,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2974,6 +3033,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3020,6 +3080,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3050,6 +3111,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3080,6 +3142,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3118,6 +3181,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3156,6 +3220,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3186,6 +3251,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3224,6 +3290,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3258,6 +3325,7 @@
             "letter": "Q"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3288,6 +3356,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3318,6 +3387,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3352,6 +3422,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3386,6 +3457,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3416,6 +3488,7 @@
             "letter": "I"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3446,6 +3519,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3488,6 +3562,7 @@
             "letter": "X"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3526,6 +3601,7 @@
             "letter": "V"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3564,6 +3640,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3598,6 +3675,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3628,6 +3706,7 @@
             "letter": "D"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3658,6 +3737,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3688,6 +3768,7 @@
             "letter": "W"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3718,6 +3799,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3748,6 +3830,7 @@
             "letter": "W"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3778,6 +3861,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3808,6 +3892,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3838,6 +3923,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3868,6 +3954,7 @@
             "letter": "Z"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",

--- a/packages/xd-crossword-tools/tests/packages/xd-crossword-tools/tests/output/fail_bad_meta.xd.json
+++ b/packages/xd-crossword-tools/tests/packages/xd-crossword-tools/tests/output/fail_bad_meta.xd.json
@@ -922,6 +922,7 @@
             "letter": "B"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -952,6 +953,7 @@
             "letter": "D"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -990,6 +992,7 @@
             "letter": "F"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1028,6 +1031,7 @@
             "letter": "M"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1058,6 +1062,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1096,6 +1101,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1134,6 +1140,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1164,6 +1171,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1202,6 +1210,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1236,6 +1245,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1266,6 +1276,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1300,6 +1311,7 @@
             "letter": "H"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1338,6 +1350,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1372,6 +1385,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1418,6 +1432,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1448,6 +1463,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1478,6 +1494,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1520,6 +1537,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1570,6 +1588,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1600,6 +1619,7 @@
             "letter": "I"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1630,6 +1650,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1660,6 +1681,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1710,6 +1732,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1752,6 +1775,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1782,6 +1806,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1812,6 +1837,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1858,6 +1884,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1892,6 +1919,7 @@
             "letter": "P"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1930,6 +1958,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1964,6 +1993,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -1994,6 +2024,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2028,6 +2059,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2066,6 +2098,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2096,6 +2129,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2134,6 +2168,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2172,6 +2207,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2202,6 +2238,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2240,6 +2277,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2278,6 +2316,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2308,6 +2347,7 @@
             "letter": "X"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2342,6 +2382,7 @@
             "letter": "Z"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2374,6 +2415,7 @@
             "letter": "P"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2404,6 +2446,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2434,6 +2477,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2464,6 +2508,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2506,6 +2551,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2544,6 +2590,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2574,6 +2621,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2608,6 +2656,7 @@
             "letter": "G"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2646,6 +2695,7 @@
             "letter": "K"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2676,6 +2726,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2706,6 +2757,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2736,6 +2788,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2766,6 +2819,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2800,6 +2854,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2834,6 +2889,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2864,6 +2920,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2894,6 +2951,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2940,6 +2998,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -2978,6 +3037,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3012,6 +3072,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3058,6 +3119,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3088,6 +3150,7 @@
             "letter": "N"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3118,6 +3181,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3156,6 +3220,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3194,6 +3259,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3224,6 +3290,7 @@
             "letter": "R"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3262,6 +3329,7 @@
             "letter": "S"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3296,6 +3364,7 @@
             "letter": "Q"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3326,6 +3395,7 @@
             "letter": "O"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3356,6 +3426,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3390,6 +3461,7 @@
             "letter": "L"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3424,6 +3496,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3454,6 +3527,7 @@
             "letter": "I"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3484,6 +3558,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3526,6 +3601,7 @@
             "letter": "X"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3564,6 +3640,7 @@
             "letter": "V"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3602,6 +3679,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3636,6 +3714,7 @@
             "letter": "E"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3666,6 +3745,7 @@
             "letter": "D"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3696,6 +3776,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3726,6 +3807,7 @@
             "letter": "W"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3756,6 +3838,7 @@
             "letter": "A"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3786,6 +3869,7 @@
             "letter": "W"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3816,6 +3900,7 @@
             "letter": "Y"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3846,6 +3931,7 @@
             "letter": "U"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3876,6 +3962,7 @@
             "letter": "T"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",
@@ -3906,6 +3993,7 @@
             "letter": "Z"
           }
         ],
+        "metadata": {},
         "display": [
           [
             "text",


### PR DESCRIPTION
For everyone, now JSONToXD will include the unknown sections

Updates the amuse data import now that I've seen some examples:

- For fields in the JSON with raw html we add a section for
- More file-wide attributes show in the metadata section
- Fix to tile import (x/y switched by accident)
- Adds support for: Bars and Circles
- Adds support for "reveal" texts
- Converts inline HTML in clue bodies to the xd markup format