### PR TITLE
Adds a fallback for missing data on an amuse import

### DIFF
--- a/packages/xd-crossword-tools/src/amuseJSONToXD.ts
+++ b/packages/xd-crossword-tools/src/amuseJSONToXD.ts
@@ -2,7 +2,6 @@ import { JSONToXD } from "./JSONtoXD"
 import type { Clue, Position as CluePosition, CrosswordJSON, Report } from "xd-crossword-tools-parser"
 
 import type { CellInfo, PlacedWord, AmuseTopLevel } from "./amuseJSONToXD.types.d.ts"
-import { doesNotReject } from "assert"
 
 /** Convert an Amuse JSON to an XD file. */
 export const amuseToXD = (amuseJSON: AmuseTopLevel) => JSONToXD(convertAmuseToCrosswordJSON(amuseJSON))
@@ -429,8 +428,15 @@ export function convertHtmlToXdMarkup(html: string | undefined): string {
     )
   }
 
+  // Don't think this is actually a goal: https://github.com/puzzmo-com/xd-crossword-tools/issues/46
+  // Convert spaced dots to ellipsis
+  // result = result.replace(/\. \. \./g, "…")
+
   // Clean up excessive whitespace and newlines
   result = result.replace(/\n+/g, "\n").trim()
+
+  // Remove extra HTML entities like "&#039;"
+  result = result.replace(/&#(\d+);/g, (match, dec) => String.fromCharCode(dec))
 
   return result
 }

--- a/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/amuseJSONToXD.test.ts
@@ -16,7 +16,7 @@ const shouldRunTests = existsSync(fullExamplePath) && existsSync(hasCirclesPath)
 
 const describeConditional = shouldRunTests ? describe : describe.skip
 
-describe("amuseJSONToXD", () => {
+describeConditional("amuseJSONToXD", () => {
   it("handles schrodinger clues correctly", () => {
     const result = convertAmuseToCrosswordJSON(schrodingerAmuseExample)
 
@@ -200,6 +200,13 @@ describe("amuseJSONToXD", () => {
 
         console.warn = consoleSpy.warn
       })
+    })
+
+    it.skip("handles converting ellipsis", () => {
+      const result = convertAmuseToCrosswordJSON(amuseJSON)
+
+      const across7 = result.clues.across.find((clue) => clue.number === 7)
+      expect(across7?.body).toMatchInlineSnapshot(`"Single ensign full of exuberance … (4)"`)
     })
 
     describe("amuseToXD", () => {


### PR DESCRIPTION
Fixes #47 - looks like maybe an older import

I have it now marking as failing when it can't determine across/downs