### PR TITLE
Preserve inline markup when converting JPZ to xd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This isn't a comprehensive doc because to our knowledge there are no OSS consumers of this lib, but for posterities sake here are the breaking changes:
 
+### 13.1.0
+
+- Switched the xml parsing library from xml-parser to fast-xml-parser. It may claim to be faster, but it can handle more complicated XML setups. This is mostly useful for the jpz -> xd clue parsing which should cover more cases now
+
 ### 13.0.0
 
 - All formatting types (bold, italics, strike, underscore, subscript, superscript, link, color) now have a required `children` field containing parsed inner components. This enables nested markup like `{*{/bold italic/}*}` or `{*bold {/and italic/} text*}`.

--- a/packages/xd-crossword-tools/package.json
+++ b/packages/xd-crossword-tools/package.json
@@ -13,11 +13,10 @@
     "postpublish": "rm ./README.md"
   },
   "dependencies": {
-    "xd-crossword-tools-parser": "workspace:*",
-    "xml-parser": "1.2.1"
+    "fast-xml-parser": "^5.5.12",
+    "xd-crossword-tools-parser": "workspace:*"
   },
   "devDependencies": {
-    "@types/xml-parser": "1.2.33",
     "tsup": "^8.1.0"
   },
   "repository": {

--- a/packages/xd-crossword-tools/src/jpzToXD.ts
+++ b/packages/xd-crossword-tools/src/jpzToXD.ts
@@ -1,132 +1,170 @@
 import { Clue, CrosswordJSON, Tile } from "xd-crossword-tools-parser"
 import { JSONToXD } from "./JSONtoXD"
-import parse from "xml-parser"
+import { XMLParser } from "fast-xml-parser"
 import { LetterTile } from "xd-crossword-tools-parser"
 
-/**
- * Extracts the raw inner XML of every <clue> element, keyed by its `word`
- * attribute. The xml-parser library used elsewhere in this file does not
- * preserve mixed content (text after child tags is dropped), so for clues
- * with inline markup like <i>...</i> we have to read the original XML.
- */
-function extractRawClueInnerXML(xmlString: string): { [wordId: string]: string } {
-  const map: { [wordId: string]: string } = {}
-  const clueRegex = /<clue\b([^>]*)>([\s\S]*?)<\/clue>/g
-  let m: RegExpExecArray | null
-  while ((m = clueRegex.exec(xmlString)) !== null) {
-    const attrs = m[1]
-    const inner = m[2]
-    const wordMatch = attrs.match(/\bword\s*=\s*["']([^"']*)["']/)
-    if (wordMatch) map[wordMatch[1]] = inner
-  }
-  return map
+// -- fast-xml-parser preserveOrder helpers --
+// With preserveOrder: true, each node is an object like:
+//   { tagName: [...children], ":@": { attr1: "val", ... } }
+// Text nodes are: { "#text": "some text" }
+
+type FxpNode = { [key: string]: any }
+
+/** Get the tag name of a node (first key that isn't ":@" or "#text") */
+function nodeName(node: FxpNode): string | undefined {
+  return Object.keys(node).find((k) => k !== ":@" && k !== "#text")
 }
 
-/**
- * Converts JPZ-style inline HTML markup inside a clue body to xd markup.
- * Supports <i>/<em>, <b>/<strong>, <u>, <s>/<strike>/<del>, <a href>, and <img>.
- * Strips an optional wrapping <span> and any unknown tags (keeping their text).
- */
-function convertInlineXMLToXDMarkup(xml: string): string {
-  let result = xml.trim()
+/** Get the children array of a node */
+function nodeChildren(node: FxpNode): FxpNode[] {
+  const name = nodeName(node)
+  return name ? node[name] : []
+}
 
-  // Strip a single outer <span>...</span> wrapper if present
-  const spanMatch = result.match(/^<span\b[^>]*>([\s\S]*)<\/span>\s*$/)
-  if (spanMatch) result = spanMatch[1].trim()
+/** Get an attribute value from a node */
+function attr(node: FxpNode, key: string): string | undefined {
+  return node[":@"]?.[key]
+}
 
-  // <img src alt /> → {![src|alt]!}
-  result = result.replace(/<img\b([^>]*?)\/?>(?:\s*<\/img>)?/g, (_match, attrs) => {
-    const srcMatch = attrs.match(/\bsrc\s*=\s*["']([^"']*)["']/)
-    const altMatch = attrs.match(/\balt\s*=\s*["']([^"']*)["']/)
-    const src = srcMatch ? srcMatch[1] : ""
-    const alt = altMatch ? altMatch[1] : ""
-    return alt ? `{![${src}|${alt}]!}` : `{![${src}]!}`
-  })
+/** Find first child element with the given tag name */
+function findChild(nodes: FxpNode[], name: string): FxpNode | undefined {
+  return nodes.find((n) => nodeName(n) === name)
+}
 
-  const conversions: Array<{ tags: string[]; open: string; close: string }> = [
-    { tags: ["i", "em"], open: "{/", close: "/}" },
-    { tags: ["b", "strong"], open: "{*", close: "*}" },
-    { tags: ["u"], open: "{_", close: "_}" },
-    { tags: ["s", "strike", "del"], open: "{-", close: "-}" },
-  ]
+/** Filter child elements by tag name */
+function filterChildren(nodes: FxpNode[], name: string): FxpNode[] {
+  return nodes.filter((n) => nodeName(n) === name)
+}
 
-  // Convert paired inline tags. Repeat until stable so nested tags collapse
-  // innermost-first (after the inner tag is replaced with xd markup it no
-  // longer contains "<", so the outer regex matches).
-  let prev: string
-  do {
-    prev = result
-    for (const { tags, open, close } of conversions) {
-      const re = new RegExp(`<(${tags.join("|")})\\b[^>]*>([^<]*?)</\\1>`, "g")
-      result = result.replace(re, (_m, _tag, content) => `${open}${content}${close}`)
+/** Get plain text content from a node's children, stripping all tags */
+function textContent(nodes: FxpNode[]): string {
+  let result = ""
+  for (const n of nodes) {
+    if ("#text" in n) {
+      result += n["#text"]
+    } else {
+      result += textContent(nodeChildren(n))
     }
-    // <a href="URL">TEXT</a> → {@TEXT|URL@}
-    result = result.replace(/<a\b([^>]*)>([^<]*?)<\/a>/g, (_m, attrs, text) => {
-      const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']*)["']/)
-      const href = hrefMatch ? hrefMatch[1] : ""
-      return `{@${text}|${href}@}`
-    })
-  } while (result !== prev)
-
-  // Drop any remaining unknown tags but preserve their text content.
-  result = result.replace(/<\/?[^>]+>/g, "")
-
+  }
   return result
 }
 
 /**
- * Replaces the body of every `<clue>` element with a flat `<span>` containing
- * just its text content, stripping inline child tags like `<i>` or `<b>`.
- *
- * The xml-parser library used here cannot handle mixed content (it loses any
- * text that appears after a child tag), and a broken parse cascades — sibling
- * `<clues>` elements then go missing too. Pre-flattening clue bodies keeps the
- * surrounding structure parseable. The original XML is still inspected via
- * `extractRawClueInnerXML` to recover the inline markup.
+ * Converts a fast-xml-parser preserveOrder node tree into xd markup.
+ * Handles <i>/<em>, <b>/<strong>, <u>, <s>/<strike>/<del>, <a href>, and <img>.
+ * Strips an optional wrapping <span> and any unknown tags (keeping their text).
  */
-function preprocessClueBodiesForParser(xml: string): string {
-  return xml.replace(/(<clue\b[^>]*>)([\s\S]*?)(<\/clue>)/g, (_match, open: string, inner: string, close: string) => {
-    const flattened = inner.replace(/<[^>]+>/g, "")
-    return `${open}<span>${flattened}</span>${close}`
-  })
+function convertNodesToXDMarkup(nodes: FxpNode[]): string {
+  // Unwrap a single outer <span> wrapper
+  if (nodes.length === 1 && nodeName(nodes[0]) === "span") {
+    nodes = nodeChildren(nodes[0])
+  }
+
+  const tagMap: { [tag: string]: { open: string; close: string } } = {
+    i: { open: "{/", close: "/}" },
+    em: { open: "{/", close: "/}" },
+    b: { open: "{*", close: "*}" },
+    strong: { open: "{*", close: "*}" },
+    u: { open: "{_", close: "_}" },
+    s: { open: "{-", close: "-}" },
+    strike: { open: "{-", close: "-}" },
+    del: { open: "{-", close: "-}" },
+    sub: { open: "{~", close: "~}" },
+    sup: { open: "{^", close: "^}" },
+  }
+
+  let result = ""
+  for (const node of nodes) {
+    if ("#text" in node) {
+      result += node["#text"]
+      continue
+    }
+
+    const tag = nodeName(node)
+    if (!tag) continue
+    const children = nodeChildren(node)
+
+    if (tag === "img") {
+      const src = attr(node, "src") ?? ""
+      const alt = attr(node, "alt") ?? ""
+      result += alt ? `{![${src}|${alt}]!}` : `{![${src}]!}`
+    } else if (tag === "a") {
+      const href = attr(node, "href") ?? ""
+      const text = convertNodesToXDMarkup(children)
+      result += `{@${text}|${href}@}`
+    } else if (tag in tagMap) {
+      const { open, close } = tagMap[tag]
+      result += `${open}${convertNodesToXDMarkup(children)}${close}`
+    } else {
+      // Unknown tag — recurse into children, keeping text
+      result += convertNodesToXDMarkup(children)
+    }
+  }
+
+  return result
 }
+
+const fxpParser = new XMLParser({
+  preserveOrder: true,
+  ignoreAttributes: false,
+  attributeNamePrefix: "",
+  processEntities: false,
+  trimValues: false,
+})
 
 /**
  * Takes a jpz xml string and converts it to an xd file.
  */
 export function jpzToXD(xmlString: string): string {
-  const rawClueInnerByWordId = extractRawClueInnerXML(xmlString)
-  const parsed = parse(preprocessClueBodiesForParser(xmlString))
+  const parsed: FxpNode[] = fxpParser.parse(xmlString)
 
-  const rectangularPuzzle = parsed.root.children.find((child: { name: string }) => child.name === "rectangular-puzzle")
+  // The root is typically <crossword-compiler-applet>
+  const root = parsed.find((n) => nodeName(n) !== undefined && nodeName(n) !== "?xml")
+  if (!root) throw new Error("Could not find root element in JPZ")
+
+  const rootChildren = nodeChildren(root)
+  const rectangularPuzzle = findChild(rootChildren, "rectangular-puzzle")
   if (!rectangularPuzzle) throw new Error("Could not find rectangular-puzzle element in JPZ")
 
-  const metadataEl = rectangularPuzzle.children.find((child: { name: string }) => child.name === "metadata")
+  const rpChildren = nodeChildren(rectangularPuzzle)
+  const metadataEl = findChild(rpChildren, "metadata")
   if (!metadataEl) throw new Error("Could not find metadata element in JPZ")
 
-  const crosswordEl = rectangularPuzzle.children.find((child: { name: string }) => child.name === "crossword")
+  const crosswordEl = findChild(rpChildren, "crossword")
   if (!crosswordEl) throw new Error("Could not find crossword element in JPZ")
 
-  const gridEl = crosswordEl.children.find((child: { name: string }) => child.name === "grid")
+  const cwChildren = nodeChildren(crosswordEl)
+  const gridEl = findChild(cwChildren, "grid")
   if (!gridEl) throw new Error("Could not find grid element in JPZ")
 
-  const cluesEls = crosswordEl.children.filter((child: { name: string }) => child.name === "clues")
+  const cluesEls = filterChildren(cwChildren, "clues")
   if (cluesEls.length !== 2) throw new Error("Expected exactly two clues elements in JPZ")
 
-  const title = metadataEl.children.find((c: { name: string }) => c.name === "title")?.content ?? "Untitled"
+  const metaChildren = nodeChildren(metadataEl)
+  const titleEl = findChild(metaChildren, "title")
+  const title = titleEl ? textContent(nodeChildren(titleEl)).trim() : "Untitled"
 
   // Grabbing metadata from the JPZ file
   const meta: CrosswordJSON["meta"] = {
     title,
-    author: metadataEl.children.find((c: { name: string }) => c.name === "creator")?.content ?? "Unknown Author",
+    author: (() => {
+      const el = findChild(metaChildren, "creator")
+      return el ? textContent(nodeChildren(el)).trim() : "Unknown Author"
+    })(),
     editor: title.includes("edited by") ? title.split("edited by")[1].trim() : "",
-    date: metadataEl.children.find((c: { name: string }) => c.name === "created_at")?.content ?? "",
-    copyright: metadataEl.children.find((c: { name: string }) => c.name === "copyright")?.content ?? "",
+    date: (() => {
+      const el = findChild(metaChildren, "created_at")
+      return el ? textContent(nodeChildren(el)).trim() : ""
+    })(),
+    copyright: (() => {
+      const el = findChild(metaChildren, "copyright")
+      return el ? textContent(nodeChildren(el)).trim() : ""
+    })(),
   }
 
   // Extracting the grid
-  const gridWidth = parseInt(gridEl.attributes.width, 10)
-  const gridHeight = parseInt(gridEl.attributes.height, 10)
+  const gridWidth = parseInt(attr(gridEl, "width")!, 10)
+  const gridHeight = parseInt(attr(gridEl, "height")!, 10)
   const tiles: Tile[][] = Array.from({ length: gridHeight }, () => Array(gridWidth).fill({ type: "blank" }))
   const numberPositions: { [num: string]: { row: number; col: number } } = {}
 
@@ -134,47 +172,48 @@ export function jpzToXD(xmlString: string): string {
   const cellBars: { [key: string]: { left?: boolean; top?: boolean } } = {}
   let hasAnyBars = false
 
-  for (const cell of gridEl.children) {
-    if (cell.name !== "cell") continue
-    const x = parseInt(cell.attributes.x, 10) - 1 // 1-based to 0-based
-    const y = parseInt(cell.attributes.y, 10) - 1 // 1-based to 0-based
+  const gridChildren = nodeChildren(gridEl)
+  for (const cell of filterChildren(gridChildren, "cell")) {
+    const x = parseInt(attr(cell, "x")!, 10) - 1 // 1-based to 0-based
+    const y = parseInt(attr(cell, "y")!, 10) - 1 // 1-based to 0-based
 
-    if (cell.attributes.type === "block") {
+    if (attr(cell, "type") === "block") {
       tiles[y][x] = { type: "blank" }
     } else {
       // Check if there are any definitions for bars
       const barAttributes = ["left-bar", "right-bar", "top-bar", "bottom-bar"]
-      if (barAttributes.some((attr) => cell.attributes[attr] === "true")) meta.form = "barred"
+      if (barAttributes.some((a) => attr(cell, a) === "true")) meta.form = "barred"
 
       const tile: LetterTile = {
         type: "letter",
-        letter: cell.attributes.solution ?? "?", // Use '?' if solution missing
+        letter: attr(cell, "solution") ?? "?", // Use '?' if solution missing
       }
 
-      if (cell.attributes.number) {
-        numberPositions[cell.attributes.number] = { row: y, col: x }
+      const num = attr(cell, "number")
+      if (num) {
+        numberPositions[num] = { row: y, col: x }
       }
 
       // Collect bar information for this cell
       const bars: { left?: boolean; top?: boolean } = {}
-      if (cell.attributes["left-bar"] === "true") {
+      if (attr(cell, "left-bar") === "true") {
         bars.left = true
         hasAnyBars = true
       }
-      if (cell.attributes["top-bar"] === "true") {
+      if (attr(cell, "top-bar") === "true") {
         bars.top = true
         hasAnyBars = true
       }
 
       // Note: right-bar and bottom-bar are converted to left-bar and top-bar on adjacent cells
       // For the XD format, we need to store them on the adjacent cells
-      if (cell.attributes["right-bar"] === "true" && x < gridWidth - 1) {
+      if (attr(cell, "right-bar") === "true" && x < gridWidth - 1) {
         const key = `${y},${x + 1}`
         if (!cellBars[key]) cellBars[key] = {}
         cellBars[key].left = true
         hasAnyBars = true
       }
-      if (cell.attributes["bottom-bar"] === "true" && y < gridHeight - 1) {
+      if (attr(cell, "bottom-bar") === "true" && y < gridHeight - 1) {
         const key = `${y + 1},${x}`
         if (!cellBars[key]) cellBars[key] = {}
         cellBars[key].top = true
@@ -194,17 +233,17 @@ export function jpzToXD(xmlString: string): string {
   }
 
   // Extract word definitions to get answers
-  const wordEls = crosswordEl.children.filter((child: { name: string }) => child.name === "word")
+  const wordEls = filterChildren(cwChildren, "word")
   const wordAnswers: { [wordId: string]: string } = {}
 
   for (const wordEl of wordEls) {
-    const wordID = wordEl.attributes.id
-    const cellsEls = wordEl.children.filter((child: { name: string }) => child.name === "cells")
+    const wordID = attr(wordEl, "id")!
+    const cellsEls = filterChildren(nodeChildren(wordEl), "cells")
     let answer = ""
 
     for (const cellEl of cellsEls) {
-      const x = parseInt(cellEl.attributes.x, 10) - 1
-      const y = parseInt(cellEl.attributes.y, 10) - 1
+      const x = parseInt(attr(cellEl, "x")!, 10) - 1
+      const y = parseInt(attr(cellEl, "y")!, 10) - 1
       const tile = tiles[y][x]
       if (tile.type === "letter") {
         answer += tile.letter
@@ -218,31 +257,22 @@ export function jpzToXD(xmlString: string): string {
   const clues: CrosswordJSON["clues"] = { across: [], down: [] }
 
   for (const cluesEl of cluesEls) {
-    const titleEl = cluesEl.children.find((c: { name: string }) => c.name === "title")
-    const direction = (titleEl?.children?.length || 0) > 0 ? titleEl?.children[0]?.content?.toLowerCase() : titleEl?.content?.toLowerCase()
+    const cluesChildren = nodeChildren(cluesEl)
+    const titleNode = findChild(cluesChildren, "title")
+    const titleChildren = titleNode ? nodeChildren(titleNode) : []
+    const direction = textContent(titleChildren).toLowerCase().trim()
 
     if (!direction || (direction !== "across" && direction !== "down")) continue
 
-    for (const clueEl of cluesEl.children) {
-      if (clueEl.name !== "clue") continue
+    for (const clueEl of filterChildren(cluesChildren, "clue")) {
+      const num = attr(clueEl, "number")!
+      const wordID = attr(clueEl, "word")!
+      const clueChildren = nodeChildren(clueEl)
 
-      const num = clueEl.attributes.number
-      const wordID = clueEl.attributes.word
-      let text = ""
+      // Convert the clue's child nodes (which may contain mixed content
+      // like <i>, <b>, etc.) directly to xd markup
+      const text = convertNodesToXDMarkup(clueChildren).trim()
 
-      // Prefer the raw inner XML so inline markup (e.g. <i>...</i>) is
-      // preserved — xml-parser drops mixed content after the first child tag.
-      const rawInner = wordID ? rawClueInnerByWordId[wordID] : undefined
-      if (rawInner !== undefined) {
-        text = convertInlineXMLToXDMarkup(rawInner)
-      } else if (clueEl.children.length > 0) {
-        // Fallback: sometimes the clue text is wrapped in a span element
-        const textEl = clueEl.children.find((c: { name: string }) => c.name === "span")
-        text = textEl?.content ?? ""
-      } else {
-        // Fallback: sometimes its not
-        text = clueEl.content ?? ""
-      }
       const pos = numberPositions[num]
       if (!pos) {
         console.warn(`Could not find position for clue number ${num}`)

--- a/packages/xd-crossword-tools/src/jpzToXD.ts
+++ b/packages/xd-crossword-tools/src/jpzToXD.ts
@@ -4,10 +4,99 @@ import parse from "xml-parser"
 import { LetterTile } from "xd-crossword-tools-parser"
 
 /**
+ * Extracts the raw inner XML of every <clue> element, keyed by its `word`
+ * attribute. The xml-parser library used elsewhere in this file does not
+ * preserve mixed content (text after child tags is dropped), so for clues
+ * with inline markup like <i>...</i> we have to read the original XML.
+ */
+function extractRawClueInnerXML(xmlString: string): { [wordId: string]: string } {
+  const map: { [wordId: string]: string } = {}
+  const clueRegex = /<clue\b([^>]*)>([\s\S]*?)<\/clue>/g
+  let m: RegExpExecArray | null
+  while ((m = clueRegex.exec(xmlString)) !== null) {
+    const attrs = m[1]
+    const inner = m[2]
+    const wordMatch = attrs.match(/\bword\s*=\s*["']([^"']*)["']/)
+    if (wordMatch) map[wordMatch[1]] = inner
+  }
+  return map
+}
+
+/**
+ * Converts JPZ-style inline HTML markup inside a clue body to xd markup.
+ * Supports <i>/<em>, <b>/<strong>, <u>, <s>/<strike>/<del>, <a href>, and <img>.
+ * Strips an optional wrapping <span> and any unknown tags (keeping their text).
+ */
+function convertInlineXMLToXDMarkup(xml: string): string {
+  let result = xml.trim()
+
+  // Strip a single outer <span>...</span> wrapper if present
+  const spanMatch = result.match(/^<span\b[^>]*>([\s\S]*)<\/span>\s*$/)
+  if (spanMatch) result = spanMatch[1].trim()
+
+  // <img src alt /> → {![src|alt]!}
+  result = result.replace(/<img\b([^>]*?)\/?>(?:\s*<\/img>)?/g, (_match, attrs) => {
+    const srcMatch = attrs.match(/\bsrc\s*=\s*["']([^"']*)["']/)
+    const altMatch = attrs.match(/\balt\s*=\s*["']([^"']*)["']/)
+    const src = srcMatch ? srcMatch[1] : ""
+    const alt = altMatch ? altMatch[1] : ""
+    return alt ? `{![${src}|${alt}]!}` : `{![${src}]!}`
+  })
+
+  const conversions: Array<{ tags: string[]; open: string; close: string }> = [
+    { tags: ["i", "em"], open: "{/", close: "/}" },
+    { tags: ["b", "strong"], open: "{*", close: "*}" },
+    { tags: ["u"], open: "{_", close: "_}" },
+    { tags: ["s", "strike", "del"], open: "{-", close: "-}" },
+  ]
+
+  // Convert paired inline tags. Repeat until stable so nested tags collapse
+  // innermost-first (after the inner tag is replaced with xd markup it no
+  // longer contains "<", so the outer regex matches).
+  let prev: string
+  do {
+    prev = result
+    for (const { tags, open, close } of conversions) {
+      const re = new RegExp(`<(${tags.join("|")})\\b[^>]*>([^<]*?)</\\1>`, "g")
+      result = result.replace(re, (_m, _tag, content) => `${open}${content}${close}`)
+    }
+    // <a href="URL">TEXT</a> → {@TEXT|URL@}
+    result = result.replace(/<a\b([^>]*)>([^<]*?)<\/a>/g, (_m, attrs, text) => {
+      const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']*)["']/)
+      const href = hrefMatch ? hrefMatch[1] : ""
+      return `{@${text}|${href}@}`
+    })
+  } while (result !== prev)
+
+  // Drop any remaining unknown tags but preserve their text content.
+  result = result.replace(/<\/?[^>]+>/g, "")
+
+  return result
+}
+
+/**
+ * Replaces the body of every `<clue>` element with a flat `<span>` containing
+ * just its text content, stripping inline child tags like `<i>` or `<b>`.
+ *
+ * The xml-parser library used here cannot handle mixed content (it loses any
+ * text that appears after a child tag), and a broken parse cascades — sibling
+ * `<clues>` elements then go missing too. Pre-flattening clue bodies keeps the
+ * surrounding structure parseable. The original XML is still inspected via
+ * `extractRawClueInnerXML` to recover the inline markup.
+ */
+function preprocessClueBodiesForParser(xml: string): string {
+  return xml.replace(/(<clue\b[^>]*>)([\s\S]*?)(<\/clue>)/g, (_match, open: string, inner: string, close: string) => {
+    const flattened = inner.replace(/<[^>]+>/g, "")
+    return `${open}<span>${flattened}</span>${close}`
+  })
+}
+
+/**
  * Takes a jpz xml string and converts it to an xd file.
  */
 export function jpzToXD(xmlString: string): string {
-  const parsed = parse(xmlString)
+  const rawClueInnerByWordId = extractRawClueInnerXML(xmlString)
+  const parsed = parse(preprocessClueBodiesForParser(xmlString))
 
   const rectangularPuzzle = parsed.root.children.find((child: { name: string }) => child.name === "rectangular-puzzle")
   if (!rectangularPuzzle) throw new Error("Could not find rectangular-puzzle element in JPZ")
@@ -138,14 +227,20 @@ export function jpzToXD(xmlString: string): string {
       if (clueEl.name !== "clue") continue
 
       const num = clueEl.attributes.number
+      const wordID = clueEl.attributes.word
       let text = ""
 
-      // Sometimes, the clue text is wrapped in a span element
-      if (clueEl.children.length > 0) {
+      // Prefer the raw inner XML so inline markup (e.g. <i>...</i>) is
+      // preserved — xml-parser drops mixed content after the first child tag.
+      const rawInner = wordID ? rawClueInnerByWordId[wordID] : undefined
+      if (rawInner !== undefined) {
+        text = convertInlineXMLToXDMarkup(rawInner)
+      } else if (clueEl.children.length > 0) {
+        // Fallback: sometimes the clue text is wrapped in a span element
         const textEl = clueEl.children.find((c: { name: string }) => c.name === "span")
         text = textEl?.content ?? ""
       } else {
-        // Sometimes its not
+        // Fallback: sometimes its not
         text = clueEl.content ?? ""
       }
       const pos = numberPositions[num]
@@ -154,7 +249,6 @@ export function jpzToXD(xmlString: string): string {
         continue
       }
 
-      const wordID = clueEl.attributes.word
       const answer = wordAnswers[wordID] || ""
 
       // Skip clues without valid answers

--- a/packages/xd-crossword-tools/src/uclickToXD.ts
+++ b/packages/xd-crossword-tools/src/uclickToXD.ts
@@ -2,12 +2,17 @@
 // Which does not actually work, this code would need to be changed to better
 // handle formatting
 //
-import parse from "xml-parser"
+import { XMLParser } from "fast-xml-parser"
+
+const fxpParser = new XMLParser({ preserveOrder: true, ignoreAttributes: false, attributeNamePrefix: "" })
 
 export const uclickXMLToXD = (str: string) => {
-  const parsed = parse(str)
-  const crossword = parsed.root.children.find((child: { name: string }) => child.name === "crossword")
-  if (!crossword) throw new Error("Could not find crossword element in XML")
+  const parsed = fxpParser.parse(str) as any[]
+  const root = parsed.find((n: any) => Object.keys(n).some((k) => k !== ":@" && k !== "#text"))!
+  const rootKey = Object.keys(root).find((k) => k !== ":@" && k !== "#text")!
+  const rootChildren: any[] = root[rootKey]
+  const crosswordNode = rootChildren.find((n: any) => "crossword" in n)
+  if (!crosswordNode) throw new Error("Could not find crossword element in XML")
 
   let width = -1
   let metaRaw: Record<string, string> = {}
@@ -15,33 +20,41 @@ export const uclickXMLToXD = (str: string) => {
   const downs: string[] = []
   const acrosses: string[] = []
 
+  const cwChildren: any[] = crosswordNode["crossword"]
+
   // Process all elements
-  crossword.children.forEach((element: any) => {
-    if (element.name === "Width") {
-      width = Number(element.attributes.v)
-    } else if (element.name === "AllAnswer") {
-      answer = element.attributes.v.replace(/-/g, ".")
-    } else if (element.name === "across") {
-      element.children.forEach((clue: any) => {
-        if (clue.name.startsWith("a")) {
-          const i = clue.name.slice(1)
-          const answer = clue.attributes.a
-          const c = decodeURIComponent(clue.attributes.c)
-          acrosses.push(`${i}. ${c} ~ ${answer}`)
-        }
+  cwChildren.forEach((element: any) => {
+    const name = Object.keys(element).find((k) => k !== ":@" && k !== "#text")
+    if (!name) return
+    const attrs = element[":@"] || {}
+
+    if (name === "Width") {
+      width = Number(attrs.v)
+    } else if (name === "AllAnswer") {
+      answer = attrs.v.replace(/-/g, ".")
+    } else if (name === "across") {
+      ;(element[name] as any[]).forEach((clue: any) => {
+        const clueName = Object.keys(clue).find((k) => k !== ":@" && k !== "#text")
+        if (!clueName || !clueName.startsWith("a")) return
+        const clueAttrs = clue[":@"] || {}
+        const i = clueName.slice(1)
+        const answer = clueAttrs.a
+        const c = decodeURIComponent(clueAttrs.c)
+        acrosses.push(`${i}. ${c} ~ ${answer}`)
       })
-    } else if (element.name === "down") {
-      element.children.forEach((clue: any) => {
-        if (clue.name.startsWith("d")) {
-          const i = clue.name.slice(1)
-          const answer = clue.attributes.a
-          const c = decodeURIComponent(clue.attributes.c)
-          downs.push(`${i}. ${c} ~ ${answer}`)
-        }
+    } else if (name === "down") {
+      ;(element[name] as any[]).forEach((clue: any) => {
+        const clueName = Object.keys(clue).find((k) => k !== ":@" && k !== "#text")
+        if (!clueName || !clueName.startsWith("d")) return
+        const clueAttrs = clue[":@"] || {}
+        const i = clueName.slice(1)
+        const answer = clueAttrs.a
+        const c = decodeURIComponent(clueAttrs.c)
+        downs.push(`${i}. ${c} ~ ${answer}`)
       })
     } else {
       // Handle metadata
-      metaRaw[element.name] = element.attributes.v
+      metaRaw[name] = attrs.v
     }
   })
 

--- a/packages/xd-crossword-tools/tests/barredGridSnapshot.test.ts
+++ b/packages/xd-crossword-tools/tests/barredGridSnapshot.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest"
 import { readFileSync } from "fs"
-import parse from "xml-parser"
+import { XMLParser } from "fast-xml-parser"
 
 import { xdToJSON } from "xd-crossword-tools-parser/src"
 import { printBarredGrid, addBarsToTiles } from "../src/printBarredGrid"
 import { BarPosition } from "../src/printBarredGrid"
 import { jpzToXD } from "../src/jpzToXD"
+
+const fxpParser = new XMLParser({ preserveOrder: true, ignoreAttributes: false, attributeNamePrefix: "" })
 
 describe("barred grid snapshot", () => {
   it("should convert JPZ to JSON and visualize with bars", () => {
@@ -77,29 +79,31 @@ describe("barred grid snapshot", () => {
 
     const xdJSON = xdToJSON(parsed)
 
-    // Extract bars from JPZ directly
-    const jpzParsed = parse(jpzContent)
-    const rectangularPuzzle = jpzParsed.root.children.find((child: { name: string }) => child.name === "rectangular-puzzle")
-    const crosswordEl = rectangularPuzzle!.children.find((child: { name: string }) => child.name === "crossword")
-    const gridEl = crosswordEl!.children.find((child: { name: string }) => child.name === "grid")!
+    // Extract bars from JPZ directly using fast-xml-parser
+    const jpzParsed = fxpParser.parse(jpzContent) as any[]
+    const root = jpzParsed.find((n: any) => "crossword-compiler-applet" in n)!
+    const rpNode = root["crossword-compiler-applet"].find((n: any) => "rectangular-puzzle" in n)!
+    const cwNode = rpNode["rectangular-puzzle"].find((n: any) => "crossword" in n)!
+    const gridNode = cwNode["crossword"].find((n: any) => "grid" in n)!
 
     const bars: BarPosition[] = []
-    const gridWidth = parseInt(gridEl.attributes.width, 10)
-    const gridHeight = parseInt(gridEl.attributes.height, 10)
+    const gridWidth = parseInt(gridNode[":@"].width, 10)
+    const gridHeight = parseInt(gridNode[":@"].height, 10)
 
-    for (const cell of gridEl.children) {
-      if (cell.name !== "cell") continue
-      const x = parseInt(cell.attributes.x, 10) - 1
-      const y = parseInt(cell.attributes.y, 10) - 1
+    for (const child of gridNode["grid"]) {
+      if (!("cell" in child)) continue
+      const a = child[":@"]
+      const x = parseInt(a.x, 10) - 1
+      const y = parseInt(a.y, 10) - 1
 
-      if (cell.attributes["left-bar"] === "true") bars.push({ row: y, col: x, type: "left" })
-      if (cell.attributes["top-bar"] === "true") bars.push({ row: y, col: x, type: "top" })
+      if (a["left-bar"] === "true") bars.push({ row: y, col: x, type: "left" })
+      if (a["top-bar"] === "true") bars.push({ row: y, col: x, type: "top" })
 
       // Convert right-bar and bottom-bar to left-bar and top-bar on adjacent cells
-      if (cell.attributes["right-bar"] === "true" && x < gridWidth - 1) {
+      if (a["right-bar"] === "true" && x < gridWidth - 1) {
         bars.push({ row: y, col: x + 1, type: "left" })
       }
-      if (cell.attributes["bottom-bar"] === "true" && y < gridHeight - 1) {
+      if (a["bottom-bar"] === "true" && y < gridHeight - 1) {
         bars.push({ row: y + 1, col: x, type: "top" })
       }
     }

--- a/packages/xd-crossword-tools/tests/jpz/inline-style-sample.jpz
+++ b/packages/xd-crossword-tools/tests/jpz/inline-style-sample.jpz
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crossword-compiler-applet>
+  <rectangular-puzzle>
+    <metadata>
+      <creator>Nick Henriquez</creator>
+      <title>NH sample puzzle</title>
+    </metadata>
+    <crossword>
+      <grid one-letter-words="false" height="7" width="7">
+        <grid-look numbering-scheme="normal" />
+        <cell x="1" y="1" number="1" solution="H" />
+        <cell x="2" y="1" number="2" solution="U" />
+        <cell x="3" y="1" number="3" solution="R" />
+        <cell x="4" y="1" number="4" solution="L" />
+        <cell x="5" y="1" type="block" />
+        <cell x="6" y="1" type="block" />
+        <cell x="7" y="1" type="block" />
+        <cell x="1" y="2" number="5" solution="A" />
+        <cell x="2" y="2" solution="T" />
+        <cell x="3" y="2" solution="E" />
+        <cell x="4" y="2" solution="A" />
+        <cell x="5" y="2" number="6" solution="M" />
+        <cell x="6" y="2" type="block" />
+        <cell x="7" y="2" type="block" />
+        <cell x="1" y="3" number="7" solution="H" />
+        <cell x="2" y="3" solution="I" />
+        <cell x="3" y="3" solution="N" />
+        <cell x="4" y="3" solution="T" />
+        <cell x="5" y="3" solution="E" />
+        <cell x="6" y="3" number="8" solution="D" />
+        <cell x="7" y="3" type="block" />
+        <cell x="1" y="4" number="9" solution="A" />
+        <cell x="2" y="4" solution="L" />
+        <cell x="3" y="4" solution="T" />
+        <cell x="4" y="4" solution="E" />
+        <cell x="5" y="4" solution="R" />
+        <cell x="6" y="4" solution="E" />
+        <cell x="7" y="4" number="10" solution="D" />
+        <cell x="1" y="5" type="block" />
+        <cell x="2" y="5" number="11" solution="E" />
+        <cell x="3" y="5" solution="E" />
+        <cell x="4" y="5" solution="R" />
+        <cell x="5" y="5" solution="I" />
+        <cell x="6" y="5" solution="L" />
+        <cell x="7" y="5" solution="Y" />
+        <cell x="1" y="6" type="block" />
+        <cell x="2" y="6" type="block" />
+        <cell x="3" y="6" number="12" solution="D" />
+        <cell x="4" y="6" solution="A" />
+        <cell x="5" y="6" solution="N" />
+        <cell x="6" y="6" solution="T" />
+        <cell x="7" y="6" solution="E" />
+        <cell x="1" y="7" type="block" />
+        <cell x="2" y="7" type="block" />
+        <cell x="3" y="7" type="block" />
+        <cell x="4" y="7" number="13" solution="L" />
+        <cell x="5" y="7" solution="O" />
+        <cell x="6" y="7" solution="A" />
+        <cell x="7" y="7" solution="D" />
+      </grid>
+      <word id="1">
+        <cells x="1" y="1" />
+        <cells x="2" y="1" />
+        <cells x="3" y="1" />
+        <cells x="4" y="1" />
+      </word>
+      <word id="2">
+        <cells x="1" y="2" />
+        <cells x="2" y="2" />
+        <cells x="3" y="2" />
+        <cells x="4" y="2" />
+        <cells x="5" y="2" />
+      </word>
+      <word id="3">
+        <cells x="1" y="3" />
+        <cells x="2" y="3" />
+        <cells x="3" y="3" />
+        <cells x="4" y="3" />
+        <cells x="5" y="3" />
+        <cells x="6" y="3" />
+      </word>
+      <word id="4">
+        <cells x="1" y="4" />
+        <cells x="2" y="4" />
+        <cells x="3" y="4" />
+        <cells x="4" y="4" />
+        <cells x="5" y="4" />
+        <cells x="6" y="4" />
+        <cells x="7" y="4" />
+      </word>
+      <word id="5">
+        <cells x="2" y="5" />
+        <cells x="3" y="5" />
+        <cells x="4" y="5" />
+        <cells x="5" y="5" />
+        <cells x="6" y="5" />
+        <cells x="7" y="5" />
+      </word>
+      <word id="6">
+        <cells x="3" y="6" />
+        <cells x="4" y="6" />
+        <cells x="5" y="6" />
+        <cells x="6" y="6" />
+        <cells x="7" y="6" />
+      </word>
+      <word id="7">
+        <cells x="4" y="7" />
+        <cells x="5" y="7" />
+        <cells x="6" y="7" />
+        <cells x="7" y="7" />
+      </word>
+      <word id="8">
+        <cells x="1" y="1" />
+        <cells x="1" y="2" />
+        <cells x="1" y="3" />
+        <cells x="1" y="4" />
+      </word>
+      <word id="9">
+        <cells x="2" y="1" />
+        <cells x="2" y="2" />
+        <cells x="2" y="3" />
+        <cells x="2" y="4" />
+        <cells x="2" y="5" />
+      </word>
+      <word id="10">
+        <cells x="3" y="1" />
+        <cells x="3" y="2" />
+        <cells x="3" y="3" />
+        <cells x="3" y="4" />
+        <cells x="3" y="5" />
+        <cells x="3" y="6" />
+      </word>
+      <word id="11">
+        <cells x="4" y="1" />
+        <cells x="4" y="2" />
+        <cells x="4" y="3" />
+        <cells x="4" y="4" />
+        <cells x="4" y="5" />
+        <cells x="4" y="6" />
+        <cells x="4" y="7" />
+      </word>
+      <word id="12">
+        <cells x="5" y="2" />
+        <cells x="5" y="3" />
+        <cells x="5" y="4" />
+        <cells x="5" y="5" />
+        <cells x="5" y="6" />
+        <cells x="5" y="7" />
+      </word>
+      <word id="13">
+        <cells x="6" y="3" />
+        <cells x="6" y="4" />
+        <cells x="6" y="5" />
+        <cells x="6" y="6" />
+        <cells x="6" y="7" />
+      </word>
+      <word id="14">
+        <cells x="7" y="4" />
+        <cells x="7" y="5" />
+        <cells x="7" y="6" />
+        <cells x="7" y="7" />
+      </word>
+      <clues>
+        <title>
+          <b>Across</b>
+        </title>
+        <clue number="1" word="1">
+          <span>Throw</span>
+        </clue>
+        <clue number="5" word="2">
+          <span>Starters</span>
+        </clue>
+        <clue number="7" word="3">
+          <span>Got (at)</span>
+        </clue>
+        <clue number="9" word="4">
+          <span>"___ States" (Ken Russell thriller)</span>
+        </clue>
+        <clue number="11" word="5">
+          <span>In a creepy way</span>
+        </clue>
+        <clue number="12" word="6">
+          <span>Writer of the <i>Divina Commedia</i></span>
+        </clue>
+        <clue number="13" word="7">
+          <span>Washing machine unit</span>
+        </clue>
+      </clues>
+      <clues>
+        <title>
+          <b>Down</b>
+        </title>
+        <clue number="1" word="8">
+          <span>Alternative to 😂</span>
+        </clue>
+        <clue number="2" word="9">
+          <span>Of use</span>
+        </clue>
+        <clue number="3" word="10">
+          <span>Didn't own</span>
+        </clue>
+        <clue number="4" word="11">
+          <span>Pass thrown by a receiver</span>
+        </clue>
+        <clue number="6" word="12">
+          <span>Type of wool</span>
+        </clue>
+        <clue number="8" word="13">
+          <span>World's largest airline, by revenue</span>
+        </clue>
+        <clue number="10" word="14">
+          <span>Like blue hair</span>
+        </clue>
+      </clues>
+    </crossword>
+  </rectangular-puzzle>
+</crossword-compiler-applet>
+

--- a/packages/xd-crossword-tools/tests/jpzToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/jpzToXD.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest"
 const simpleJpz = readFileSync(__dirname + "/jpz/That's a Bear in a Bee Costume.jpz", "utf8")
 const complexJpz = readFileSync(__dirname + "/jpz/lil-167-ratliff-121823.jpz", "utf8")
 const jpzBarredContent = readFileSync(__dirname + "/jpz/Printer-Devilry-kyle-dolan.jpz", "utf-8")
+const inlineStyleJpz = readFileSync(__dirname + "/jpz/inline-style-sample.jpz", "utf8")
 
 describe(jpzToXD.name, () => {
   it("should parse a simple jpz file", () => {
@@ -235,5 +236,88 @@ describe(jpzToXD.name, () => {
       A.A.A...
       "
     `)
+  })
+
+  it("converts inline style tags inside clues to xd markup", () => {
+    const res = jpzToXD(inlineStyleJpz)
+    // The italicized title in clue A12 should round-trip into xd italic markup.
+    expect(res).toContain("A12. Writer of the {/Divina Commedia/} ~ DANTE")
+    expect(res).toMatchInlineSnapshot(`
+      "## Metadata
+
+      title: NH sample puzzle
+      author: Nick Henriquez
+      editor: 
+      date: 
+      copyright: 
+
+      ## Grid
+
+      HURL...
+      ATEAM..
+      HINTED.
+      ALTERED
+      .EERILY
+      ..DANTE
+      ...LOAD
+
+      ## Clues
+
+      A1. Throw ~ HURL
+      A5. Starters ~ ATEAM
+      A7. Got (at) ~ HINTED
+      A9. "___ States" (Ken Russell thriller) ~ ALTERED
+      A11. In a creepy way ~ EERILY
+      A12. Writer of the {/Divina Commedia/} ~ DANTE
+      A13. Washing machine unit ~ LOAD
+
+      D1. Alternative to 😂 ~ HAHA
+      D2. Of use ~ UTILE
+      D3. Didn't own ~ RENTED
+      D4. Pass thrown by a receiver ~ LATERAL
+      D6. Type of wool ~ MERINO
+      D8. World's largest airline, by revenue ~ DELTA
+      D10. Like blue hair ~ DYED"
+    `)
+  })
+
+  it("converts a variety of inline style tags inside clues to xd markup", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<crossword-compiler-applet>
+  <rectangular-puzzle>
+    <metadata>
+      <creator>Test</creator>
+      <title>Inline tag fixture</title>
+    </metadata>
+    <crossword>
+      <grid width="2" height="2">
+        <cell x="1" y="1" number="1" solution="A" />
+        <cell x="2" y="1" solution="B" />
+        <cell x="1" y="2" number="2" solution="C" />
+        <cell x="2" y="2" solution="D" />
+      </grid>
+      <word id="1"><cells x="1" y="1" /><cells x="2" y="1" /></word>
+      <word id="2"><cells x="1" y="2" /><cells x="2" y="2" /></word>
+      <word id="3"><cells x="1" y="1" /><cells x="1" y="2" /></word>
+      <word id="4"><cells x="2" y="1" /><cells x="2" y="2" /></word>
+      <clues>
+        <title><b>Across</b></title>
+        <clue number="1" word="1"><span>Bold <b>thing</b> here</span></clue>
+        <clue number="2" word="2"><span>Strike <s>that</s> out</span></clue>
+      </clues>
+      <clues>
+        <title><b>Down</b></title>
+        <clue number="1" word="3"><span>Underline <u>this</u> word</span></clue>
+        <clue number="2" word="4"><span>Visit <a href="https://example.com">our site</a> now</span></clue>
+      </clues>
+    </crossword>
+  </rectangular-puzzle>
+</crossword-compiler-applet>`
+
+    const res = jpzToXD(xml)
+    expect(res).toContain("A1. Bold {*thing*} here ~ AB")
+    expect(res).toContain("A2. Strike {-that-} out ~ CD")
+    expect(res).toContain("D1. Underline {_this_} word ~ AC")
+    expect(res).toContain("D2. Visit {@our site|https://example.com@} now ~ BD")
   })
 })

--- a/packages/xd-crossword-tools/tests/jpzToXD.test.ts
+++ b/packages/xd-crossword-tools/tests/jpzToXD.test.ts
@@ -303,7 +303,7 @@ describe(jpzToXD.name, () => {
       <clues>
         <title><b>Across</b></title>
         <clue number="1" word="1"><span>Bold <b>thing</b> here</span></clue>
-        <clue number="2" word="2"><span>Strike <s>that</s> out</span></clue>
+        <clue number="2" word="2"><span>H<sub>2</sub>O is <sup>super</sup> cool <s>not</s> out</span></clue>
       </clues>
       <clues>
         <title><b>Down</b></title>
@@ -316,8 +316,59 @@ describe(jpzToXD.name, () => {
 
     const res = jpzToXD(xml)
     expect(res).toContain("A1. Bold {*thing*} here ~ AB")
-    expect(res).toContain("A2. Strike {-that-} out ~ CD")
+    expect(res).toContain("A2. H{~2~}O is {^super^} cool {-not-} out ~ CD")
     expect(res).toContain("D1. Underline {_this_} word ~ AC")
     expect(res).toContain("D2. Visit {@our site|https://example.com@} now ~ BD")
+  })
+
+  it("converts nested inline tags to nested xd markup", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<crossword-compiler-applet>
+  <rectangular-puzzle>
+    <metadata>
+      <creator>Test</creator>
+      <title>Nested tag fixture</title>
+    </metadata>
+    <crossword>
+      <grid width="3" height="3">
+        <cell x="1" y="1" number="1" solution="A" />
+        <cell x="2" y="1" solution="B" />
+        <cell x="3" y="1" solution="C" />
+        <cell x="1" y="2" number="2" solution="D" />
+        <cell x="2" y="2" solution="E" />
+        <cell x="3" y="2" solution="F" />
+        <cell x="1" y="3" number="3" solution="G" />
+        <cell x="2" y="3" solution="H" />
+        <cell x="3" y="3" solution="I" />
+      </grid>
+      <word id="1"><cells x="1" y="1" /><cells x="2" y="1" /><cells x="3" y="1" /></word>
+      <word id="2"><cells x="1" y="2" /><cells x="2" y="2" /><cells x="3" y="2" /></word>
+      <word id="3"><cells x="1" y="3" /><cells x="2" y="3" /><cells x="3" y="3" /></word>
+      <word id="4"><cells x="1" y="1" /><cells x="1" y="2" /><cells x="1" y="3" /></word>
+      <word id="5"><cells x="2" y="1" /><cells x="2" y="2" /><cells x="2" y="3" /></word>
+      <word id="6"><cells x="3" y="1" /><cells x="3" y="2" /><cells x="3" y="3" /></word>
+      <clues>
+        <title><b>Across</b></title>
+        <clue number="1" word="1"><span>A <b><i>bold italic</i></b> phrase</span></clue>
+        <clue number="2" word="2"><span>Click <a href="https://example.com"><b>bold link</b></a> here</span></clue>
+        <clue number="3" word="3"><span>Some <u><i>underscored italic</i></u> text</span></clue>
+      </clues>
+      <clues>
+        <title><b>Down</b></title>
+        <clue number="1" word="4"><span>A <b>bold with <i>nested italic</i> inside</b> end</span></clue>
+        <clue number="2" word="5"><span>See <i>the <b>deep</b> nesting</i> here</span></clue>
+        <clue number="3" word="6"><span>Plain clue</span></clue>
+      </clues>
+    </crossword>
+  </rectangular-puzzle>
+</crossword-compiler-applet>`
+
+    const res = jpzToXD(xml)
+    expect(res).toContain("A1. A {*{/bold italic/}*} phrase ~ ABC")
+    expect(res).toContain("A2. Click {@{*bold link*}|https://example.com@} here ~ DEF")
+    expect(res).toContain("A3. Some {_{/underscored italic/}_} text ~ GHI")
+    expect(res).toContain("D1. A {*bold with {/nested italic/} inside*} end ~ ADG")
+    expect(res).toContain("D2. See {/the {*deep*} nesting/} here ~ BEH")
+    expect(res).toContain("D3. Plain clue ~ CFI")
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,13 +1319,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/xml-parser@npm:1.2.33":
-  version: 1.2.33
-  resolution: "@types/xml-parser@npm:1.2.33"
-  checksum: 10c0/059e3080fa854433d5ade8fffe4bc6ebd1e4bb88d2c5c2246493bc4bf14d0eea5c14ba0d532dfb3b10109f11a94a563ab76bcbd411dc37746b2a348ae5a3cd1d
-  languageName: node
-  linkType: hard
-
 "@vitejs/plugin-react-swc@npm:^3.10.2":
   version: 3.10.2
   resolution: "@vitejs/plugin-react-swc@npm:3.10.2"
@@ -2084,15 +2077,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^2.2.0":
-  version: 2.6.9
-  resolution: "debug@npm:2.6.9"
-  dependencies:
-    ms: "npm:2.0.0"
-  checksum: 10c0/121908fb839f7801180b69a7e218a40b5a0b718813b886b7d6bdb82001b931c938e2941d1e4450f33a1b1df1da653f5f7a0440c197f29fbf8a6e9d45ff6ef589
-  languageName: node
-  linkType: hard
-
 "debug@npm:^4.3.1, debug@npm:^4.4.1":
   version: 4.4.1
   resolution: "debug@npm:4.4.1"
@@ -2540,6 +2524,28 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "fast-xml-builder@npm:1.1.4"
+  dependencies:
+    path-expression-matcher: "npm:^1.1.3"
+  checksum: 10c0/d5dfc0660f7f886b9f42747e6aa1d5e16c090c804b322652f65a5d7ffb93aa00153c3e1276cd053629f9f4c4f625131dc6886677394f7048e827e63b97b18927
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^5.5.12":
+  version: 5.5.12
+  resolution: "fast-xml-parser@npm:5.5.12"
+  dependencies:
+    fast-xml-builder: "npm:^1.1.4"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.2.3"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10c0/fe2985517b7fe160b1f0529f2b285063184f21b0590c4cc65d34d464eea98f22ecad2a64575f2376d196d9e7a2e9e1a05f6603f02df4a1d6ac845aec0cda9f5b
   languageName: node
   linkType: hard
 
@@ -4005,13 +4011,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.0.0":
-  version: 2.0.0
-  resolution: "ms@npm:2.0.0"
-  checksum: 10c0/f8fda810b39fd7255bbdc451c46286e549794fcc700dc9cd1d25658bbc4dc2563a5de6fe7c60f798a16a60c6ceb53f033cb353f493f0cf63e5199b702943159d
-  languageName: node
-  linkType: hard
-
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -4196,6 +4195,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
   languageName: node
   linkType: hard
 
@@ -5481,6 +5487,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: 10c0/1ee78101f1cd73a5b32f63cfd0be501bd246801a002f5987efef903a49e9297d1b63574e302ab3c06ee5e715c524d6cbdfef010e372ec1ea848e0179836cc208
+  languageName: node
+  linkType: hard
+
 "styled-components@npm:^5.3.6":
   version: 5.3.11
   resolution: "styled-components@npm:5.3.11"
@@ -6542,23 +6555,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "xd-crossword-tools@workspace:packages/xd-crossword-tools"
   dependencies:
-    "@types/xml-parser": "npm:1.2.33"
+    fast-xml-parser: "npm:^5.5.12"
     tsup: "npm:^8.1.0"
     xd-crossword-tools-parser: "workspace:*"
-    xml-parser: "npm:1.2.1"
   bin:
     xd-crossword-tools: ./dist/cli.js
   languageName: unknown
   linkType: soft
-
-"xml-parser@npm:1.2.1":
-  version: 1.2.1
-  resolution: "xml-parser@npm:1.2.1"
-  dependencies:
-    debug: "npm:^2.2.0"
-  checksum: 10c0/ab67147321c075b2f36b48c2451e3d3a2b98bab3a346017ddb2a74b8ce35b316d8b5a1dc6ff5f2ba3f825dfc85da11ede9c79300792e7e8eaac7f936b230e8aa
-  languageName: node
-  linkType: hard
 
 "yallist@npm:^4.0.0":
   version: 4.0.0


### PR DESCRIPTION
Goal: Adds extended support for parsing JPZ's HTML clues to xd

Converts us to use a different xml parser which supports more complex XML setups